### PR TITLE
lock orientation to portrait on iphone

### DIFF
--- a/network/URnetwork-Info.plist
+++ b/network/URnetwork-Info.plist
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/network/network/AppDelegate.swift
+++ b/network/network/AppDelegate.swift
@@ -1,0 +1,19 @@
+//
+//  AppDelegate.swift
+//  URnetwork
+//
+//  Created by Stuart Kuentzel on 2024/12/30.
+//
+
+import Foundation
+import UIKit
+
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            return .allButUpsideDown
+        } else {
+            return .portrait
+        }
+    }
+}

--- a/network/network/NetworkApp.swift
+++ b/network/network/NetworkApp.swift
@@ -12,6 +12,7 @@ import GoogleSignIn
 @main
 struct NetworkApp: App {
     
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject var globalStore = GlobalStore()
     @StateObject private var snackbarManager = UrSnackbarManager()
     


### PR DESCRIPTION
- Allow only portrait for iPhone
- Allow both portrait and landscape for iPad