### PR TITLE
tunnel fixes

### DIFF
--- a/network/network/Shared/ViewModels/DeviceManager.swift
+++ b/network/network/Shared/ViewModels/DeviceManager.swift
@@ -294,12 +294,19 @@ extension DeviceManager {
                 // note ios does not allow VPN interface while offline, due to the existing interface conditions
                 // ignore `vpnInterfaceWhileOffline`
                 
+                var instanceId = localState.getInstanceId()
+                if instanceId == nil {
+                    instanceId = SdkNewId()
+                    try? localState.setInstanceId(instanceId)
+                }
+                
                 var newDeviceError: NSError?
                 
                 
                 let device = SdkNewDeviceRemoteWithDefaults(
                     networkSpace,
                     clientJwt,
+                    instanceId,
                     &newDeviceError
                 )
                 
@@ -332,7 +339,6 @@ extension DeviceManager {
                 device.setProvideWhileDisconnected(provideWhileDisconnected)
                 device.setCanRefer(canRefer)
                 
-                // FIXME when starting with network service active, it looks like remote connected but get connect location is nil. WTF need to debug this
                 // only set the location if the current location is not already equivalent
                 // this avoid resetting the connection
                 if let remoteLocation = device.getConnectLocation() {

--- a/network/network/Shared/ViewModels/VPNManager.swift
+++ b/network/network/Shared/ViewModels/VPNManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import NetworkExtension
 import URnetworkSdk
 
@@ -117,8 +118,8 @@ class VPNManager {
         if (provideEnabled || connectEnabled || !routeLocal) {
             print("start vpn")
             
-            // TODO: handle wakelock & wifi lock
-            
+            // see https://developer.apple.com/documentation/uikit/uiapplication/isidletimerdisabled
+            UIApplication.shared.isIdleTimerDisabled = true
             
             self.start()
             
@@ -127,6 +128,8 @@ class VPNManager {
             
             print("stop vpn")
             self.stop()
+            
+            UIApplication.shared.isIdleTimerDisabled = false
             
         }
         
@@ -187,6 +190,7 @@ class VPNManager {
                 "by_jwt": self.device.getApi()?.getByJwt() as Any,
                 "rpc_public_key": "test",
                 "network_space": networkSpaceJson as Any,
+                "instance_id": self.device.getInstanceId()?.string() as Any,
             ]
             
             tunnelManager.protocolConfiguration = tunnelProtocol


### PR DESCRIPTION
- enable and disable provider based on network state
- use stable instance id, which allows faster reconnecting after the network extension is killed
- device model

Depends on https://github.com/urnetwork/sdk/pull/23