### PR TITLE
immediately set can show rating as false if prompt is allowed

### DIFF
--- a/network/network/Main/Connect/ConnectView.swift
+++ b/network/network/Main/Connect/ConnectView.swift
@@ -139,10 +139,9 @@ struct ConnectView: View {
                     if let device = deviceManager.device {
                         
                         if device.getShouldShowRatingDialog() {
+                            device.setCanShowRatingDialog(false)
                             try await Task.sleep(for: .seconds(2))
                             requestReview()
-                            
-                            device.setCanShowRatingDialog(false)
                         }
                         
                     }


### PR DESCRIPTION
Previous code:
```
if device.getShouldShowRatingDialog() {
    try await Task.sleep(for: .seconds(2))
    requestReview()
    
    device.setCanShowRatingDialog(false)
}
```

Updated code:
```
if device.getShouldShowRatingDialog() {
    device.setCanShowRatingDialog(false) // set this immediately
    try await Task.sleep(for: .seconds(2))
    requestReview()
}
```

This was fired on certain connection status change. Because there is a sleep task, there was a potential for having it fired multiple times before setting CanShowRatingDialog to false.

In the updated version, if ShouldShowRatingDialog == true, we immediately set CanShowRatingDialog to false, then run the sleep task, then prompt the review.