### PR TITLE
prompt user to use the correct userauth method

### DIFF
--- a/app/network/Authenticate/LoginInitial/LoginInitialView.swift
+++ b/app/network/Authenticate/LoginInitial/LoginInitialView.swift
@@ -258,6 +258,10 @@ struct LoginInitialView: View {
             print("verificationRequired should not be hit from this view")
             navigate(.verify(userAuth))
             break
+            
+        case .incorrectAuth(let authAllowedErr):
+            snackbarManager.showSnackbar(message: authAllowedErr)
+            break
         
         case .failure(let error):
             print("auth login error: \(error.localizedDescription)")

--- a/app/network/Authenticate/LoginInitial/LoginInitialViewModel.swift
+++ b/app/network/Authenticate/LoginInitial/LoginInitialViewModel.swift
@@ -102,7 +102,26 @@ extension LoginInitialView {
                                 
                             } else {
                                 
-                                continuation.resume(throwing: NSError(domain: self.domain, code: -1, userInfo: [NSLocalizedDescriptionKey: "authAllowed missing password: \(authAllowed)"]))
+                                /**
+                                 * Trying to login with the wrong account
+                                 * ie email is used with google, but trying that same email with apple
+                                 */
+                                
+                                var acceptedAuthMethods: [String] = []
+    
+                                // loop authAllowed
+                                for i in 0..<authAllowed.len() {
+                                    acceptedAuthMethods.append(authAllowed.get(i))
+                                }
+    
+                                guard acceptedAuthMethods.isEmpty else {
+    
+                                    let errMessage = "Please login with one of: \(acceptedAuthMethods.joined(separator: ", "))."
+    
+                                    continuation.resume(returning: .incorrectAuth(errMessage))
+    
+                                    return
+                                }
                                 
                             }
                             
@@ -320,5 +339,6 @@ enum LoginError: Error {
     case googleNoResult
     case googleNoIdToken
     case inProgress
+    case incorrectAuth(_ authAllowed: String)
 }
 

--- a/app/network/Shared/Models/AuthLoginResult.swift
+++ b/app/network/Shared/Models/AuthLoginResult.swift
@@ -15,11 +15,11 @@ enum AuthLoginResult {
     case create(SdkAuthLoginArgs)
     case failure(Error)
     case verificationRequired(_ userAuth: String)
+    case incorrectAuth(_ authAllowed: String)
 }
 
 enum AuthLoginError: Error {
     case isInProgress
     case invalidResult
     case invalidArguments
-    
 }


### PR DESCRIPTION
When a user tries to use a userauth associated with a different method, prompt the user to use the correct method.
For example, if an email is associated with google, and they are trying to use apple sso associated with the same email, prompt the user to login using the google sso.