### PR TITLE
Creates UrSdkApiService as a wrapper

### DIFF
--- a/app/app.xcodeproj/project.pbxproj
+++ b/app/app.xcodeproj/project.pbxproj
@@ -77,6 +77,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		17F8BA782E18EEF300B600BE /* Exceptions for "network" folder in "networkTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Shared/Services/UrApiService/MockUrApiService.swift,
+			);
+			target = D1B95A5F2CEBDD6A00542E0E /* networkTests */;
+		};
 		D1B95A8D2CEBE76400542E0E /* Exceptions for "extension" folder in "URnetworkVPN" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -94,6 +101,9 @@
 		};
 		D1B95A512CEBDD6900542E0E /* network */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				17F8BA782E18EEF300B600BE /* Exceptions for "network" folder in "networkTests" target */,
+			);
 			path = network;
 			sourceTree = "<group>";
 		};

--- a/app/network/Main/Connect/ConnectView-iOS.swift
+++ b/app/network/Main/Connect/ConnectView-iOS.swift
@@ -30,6 +30,7 @@ struct ConnectView_iOS: View {
     
     init(
         api: SdkApi,
+        urApiService: UrApiServiceProtocol,
         logout: @escaping () -> Void,
         device: SdkDeviceRemote?,
         providerListSheetViewModel: ProviderListSheetViewModel,
@@ -40,7 +41,7 @@ struct ConnectView_iOS: View {
         self.providerListSheetViewModel = providerListSheetViewModel
         self.referralLinkViewModel = referralLinkViewModel
         
-        _providerListStore = StateObject(wrappedValue: ProviderListStore(api: api))
+        _providerListStore = StateObject(wrappedValue: ProviderListStore(urApiService: urApiService))
         
         // adds clear button to search providers text field
         UITextField.appearance().clearButtonMode = .whileEditing
@@ -176,6 +177,7 @@ struct ConnectView_iOS: View {
                         connectViewModel.connectBestAvailable()
                         providerListSheetViewModel.isPresented = false
                     },
+                    isLoading: providerListStore.providersLoading,
                     providerCountries: providerListStore.providerCountries,
                     providerPromoted: providerListStore.providerPromoted,
                     providerDevices: providerListStore.providerDevices,

--- a/app/network/Main/Connect/ConnectView-macOS.swift
+++ b/app/network/Main/Connect/ConnectView-macOS.swift
@@ -26,8 +26,8 @@ import URnetworkSdk
 
         @StateObject private var providerListStore: ProviderListStore
 
-        init(api: SdkApi) {
-            _providerListStore = StateObject(wrappedValue: ProviderListStore(api: api))
+        init(urApiService: UrApiServiceProtocol) {
+            _providerListStore = StateObject(wrappedValue: ProviderListStore(urApiService: urApiService))
         }
 
         var body: some View {

--- a/app/network/Main/Connect/ProviderListSheet/ProviderListSheetView.swift
+++ b/app/network/Main/Connect/ProviderListSheet/ProviderListSheetView.swift
@@ -16,6 +16,7 @@ struct ProviderListSheetView: View {
     var selectedProvider: SdkConnectLocation?
     var connect: (SdkConnectLocation) -> Void
     var connectBestAvailable: () -> Void
+    var isLoading: Bool
     
     /**
      * Provider lists
@@ -32,67 +33,83 @@ struct ProviderListSheetView: View {
      */
     
     var body: some View {
-        List {
+        
+        if isLoading {
             
-            if !providerBestSearchMatches.isEmpty {
-                ProviderListGroup(
-                    groupName: "Best Search Matches",
-                    providers: providerBestSearchMatches,
-                    selectedProvider: selectedProvider,
-                    connect: connect
-                )
+            VStack(alignment: .center) {
+                Spacer()
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle())
+                Spacer()
             }
-
-            if !providerPromoted.isEmpty {
-                ProviderListGroup(
-                    groupName: "Promoted Locations",
-                    providers: providerPromoted,
-                    selectedProvider: selectedProvider,
-                    connect: connect,
-                    connectBestAvailable: connectBestAvailable,
-                    isPromotedLocations: true
-                )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(themeManager.currentTheme.backgroundColor)
+            
+        } else {
+            
+            List {
+                
+                if !providerBestSearchMatches.isEmpty {
+                    ProviderListGroup(
+                        groupName: "Best Search Matches",
+                        providers: providerBestSearchMatches,
+                        selectedProvider: selectedProvider,
+                        connect: connect
+                    )
+                }
+                
+                if !providerPromoted.isEmpty {
+                    ProviderListGroup(
+                        groupName: "Promoted Locations",
+                        providers: providerPromoted,
+                        selectedProvider: selectedProvider,
+                        connect: connect,
+                        connectBestAvailable: connectBestAvailable,
+                        isPromotedLocations: true
+                    )
+                }
+                
+                if !providerCountries.isEmpty {
+                    ProviderListGroup(
+                        groupName: "Countries",
+                        providers: providerCountries,
+                        selectedProvider: selectedProvider,
+                        connect: connect
+                    )
+                }
+                
+                if !providerRegions.isEmpty {
+                    ProviderListGroup(
+                        groupName: "Regions",
+                        providers: providerRegions,
+                        selectedProvider: selectedProvider,
+                        connect: connect
+                    )
+                }
+                
+                if !providerCities.isEmpty {
+                    ProviderListGroup(
+                        groupName: "Cities",
+                        providers: providerCities,
+                        selectedProvider: selectedProvider,
+                        connect: connect
+                    )
+                }
+                
+                if !providerDevices.isEmpty {
+                    ProviderListGroup(
+                        groupName: "Devices",
+                        providers: providerDevices,
+                        selectedProvider: selectedProvider,
+                        connect: connect
+                    )
+                }
+                
+                
             }
-
-            if !providerCountries.isEmpty {
-                ProviderListGroup(
-                    groupName: "Countries",
-                    providers: providerCountries,
-                    selectedProvider: selectedProvider,
-                    connect: connect
-                )
-            }
-
-            if !providerRegions.isEmpty {
-                ProviderListGroup(
-                    groupName: "Regions",
-                    providers: providerRegions,
-                    selectedProvider: selectedProvider,
-                    connect: connect
-                )
-            }
-
-            if !providerCities.isEmpty {
-                ProviderListGroup(
-                    groupName: "Cities",
-                    providers: providerCities,
-                    selectedProvider: selectedProvider,
-                    connect: connect
-                )
-            }
-
-            if !providerDevices.isEmpty {
-                ProviderListGroup(
-                    groupName: "Devices",
-                    providers: providerDevices,
-                    selectedProvider: selectedProvider,
-                    connect: connect
-                )
-            }
-
+            .listStyle(.plain)
+            .background(themeManager.currentTheme.backgroundColor)
         }
-        .listStyle(.plain)
-        .background(themeManager.currentTheme.backgroundColor)
     }
     
 }
@@ -163,6 +180,7 @@ struct ProviderListSheetView: View {
             selectedProvider: nil,
             connect: {_ in },
             connectBestAvailable: {},
+            isLoading: false,
             providerCountries: providerCountries,
             providerPromoted: [],
             providerDevices: [],

--- a/app/network/Main/Feedback/FeedbackView.swift
+++ b/app/network/Main/Feedback/FeedbackView.swift
@@ -16,9 +16,9 @@ struct FeedbackView: View {
     @Environment(\.requestReview) private var requestReview
     @FocusState private var isFocused: Bool
     
-    init(api: SdkApi?) {
+    init(urApiService: UrApiServiceProtocol) {
         _viewModel = StateObject.init(wrappedValue: ViewModel(
-            api: api
+            urApiService: urApiService
         ))
     }
     
@@ -140,7 +140,7 @@ struct FeedbackView: View {
 
 #Preview {
     FeedbackView(
-        api: nil
+        urApiService: MockUrApiService()
     )
     .environmentObject(ThemeManager.shared)
 }

--- a/app/network/Main/Leaderboard/LeaderboardView.swift
+++ b/app/network/Main/Leaderboard/LeaderboardView.swift
@@ -14,8 +14,8 @@ struct LeaderboardView: View {
     
     @StateObject private var viewModel: ViewModel
     
-    init(api: SdkApi) {
-        _viewModel = .init(wrappedValue: .init(api: api))
+    init(api: UrApiServiceProtocol) {
+        _viewModel = .init(wrappedValue: .init(apiService: api))
     }
     
     var body: some View {
@@ -365,5 +365,5 @@ private struct LeaderboardRow: View {
 }
 
 //#Preview {
-//    LeaderboardView()
+//    LeaderboardView(api: MockUrApiService())
 //}

--- a/app/network/Main/Leaderboard/LeaderboardViewModel.swift
+++ b/app/network/Main/Leaderboard/LeaderboardViewModel.swift
@@ -13,7 +13,7 @@ extension LeaderboardView {
     @MainActor
     class ViewModel: ObservableObject {
 
-        private var api: SdkApi
+        private let urApiService: UrApiServiceProtocol
 
         @Published var networkRankingPublic: Bool = false {
             didSet {
@@ -25,8 +25,6 @@ extension LeaderboardView {
 
         @Published private(set) var leaderboardEarners: [LeaderboardEntry] = []
 
-        // @Published private(set) var networkRanking: SdkNetworkRanking? = nil
-
         @Published private(set) var networkRank: Int = 0
         @Published private(set) var netProvidedFormatted: String = ""
 
@@ -35,8 +33,8 @@ extension LeaderboardView {
 
         @Published private(set) var isSettingRankingVisibility: Bool = false
 
-        init(api: SdkApi) {
-            self.api = api
+        init(apiService: UrApiServiceProtocol) {
+            self.urApiService = apiService
 
             Task {
                 await fetchLeaderboardData()
@@ -77,42 +75,13 @@ extension LeaderboardView {
         private func getRanking() async -> Result<Void, Error> {
 
             do {
-
-                let result: SdkGetNetworkRankingResult = try await withCheckedThrowingContinuation {
-                    [weak self] continuation in
-
-                    guard let self = self else { return }
-
-                    let callback = GetNetworkRankingCallback { result, err in
-
-                        if let err = err {
-                            continuation.resume(throwing: err)
-                            return
-                        }
-
-                        if let err = result?.error {
-                            continuation.resume(
-                                throwing: LeaderboardError.resultError(message: err.message))
-                            return
-                        }
-
-                        guard let result = result else {
-                            continuation.resume(throwing: LeaderboardError.resultEmpty)
-                            return
-                        }
-
-                        continuation.resume(returning: result)
-
-                    }
-
-                    api.getNetworkLeaderboardRanking(callback)
-
-                }
+                
+                let result = try await urApiService.getLeaderboardRanking()
 
                 if let networkRanking = result.networkRanking {
                     self.networkRankingPublic = networkRanking.leaderboardPublic
                     self.networkRank = networkRanking.leaderboardRank
-                    self.netProvidedFormatted = self.formatByteSize(mib: networkRanking.netMiBCount)
+                    self.netProvidedFormatted = formatMiB(mib: networkRanking.netMiBCount)
                 }
 
                 return .success(())
@@ -128,64 +97,8 @@ extension LeaderboardView {
         private func getLeaderboard() async -> Result<Void, Error> {
 
             do {
-
-                let result: SdkLeaderboardResult = try await withCheckedThrowingContinuation {
-                    [weak self] continuation in
-
-                    guard let self = self else { return }
-
-                    let callback = GetLeaderboardCallback { result, err in
-
-                        if let err = err {
-                            continuation.resume(throwing: err)
-                            return
-                        }
-
-                        if let err = result?.error {
-                            continuation.resume(
-                                throwing: LeaderboardError.resultError(message: err.message))
-                            return
-                        }
-
-                        guard let result = result else {
-                            continuation.resume(throwing: LeaderboardError.resultEmpty)
-                            return
-                        }
-
-                        continuation.resume(returning: result)
-
-                    }
-
-                    let args = SdkGetLeaderboardArgs()
-
-                    api.getLeaderboard(args, callback: callback)
-
-                }
-
-                var earners: [LeaderboardEntry] = []
-
-                let n = result.earners?.len()
-
-                guard let n = n else {
-                    return .failure(LeaderboardError.earnersEmpty)
-                }
-
-                for i in 0..<n {
-                    let earner = result.earners?.get(i)
-
-                    if let earner = earner {
-
-                        earners.append(
-                            LeaderboardEntry(
-                                networkId: earner.networkId,
-                                networkName: earner.networkName,
-                                netProvided: self.formatByteSize(mib: earner.netMiBCount),
-                                rank: i,
-                                isPublic: earner.isPublic,
-                                containsProfanity: earner.containsProfanity
-                            ))
-                    }
-                }
+                
+                let earners = try await urApiService.getLeaderboard()
 
                 self.leaderboardEarners = earners
 
@@ -199,40 +112,6 @@ extension LeaderboardView {
 
         }
 
-        private func formatByteSize(mib: Float) -> String {
-
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 2
-            
-            let pib: Float = 1024 * 1024 * 1024
-            let tib: Float = 1024 * 1024
-            let gib: Float = 1024
-
-            // 1 GiB = 1024 MiB
-            // if mib >= 1_048_576 {  // 1 PiB = 1024 TiB = 1,048,576 GiB
-            if mib >= pib {
-                let pib = mib / pib
-                let formatted =
-                    formatter.string(from: NSNumber(value: pib)) ?? String(format: "%.2f", pib)
-                return "\(formatted) PiB"
-            } else if mib >= tib {  // 1 TiB = 1024 GiB = 1,048,576 MiB
-                let tib = mib / tib
-                let formatted =
-                    formatter.string(from: NSNumber(value: tib)) ?? String(format: "%.2f", tib)
-                return "\(formatted) TiB"
-            } else if mib >= gib {  // 1 GiB = 1024 MiB
-                let gib = mib / gib
-                let formatted =
-                    formatter.string(from: NSNumber(value: gib)) ?? String(format: "%.2f", gib)
-                return "\(formatted) GiB"
-            } else {
-                let formatted =
-                    formatter.string(from: NSNumber(value: mib)) ?? String(format: "%.2f", mib)
-                return "\(formatted) MiB"
-            }
-        }
-
         func setNetworkRankingPublic(_ isPublic: Bool) async -> Result<Void, Error> {
 
             if self.isSettingRankingVisibility {
@@ -242,40 +121,8 @@ extension LeaderboardView {
             self.isSettingRankingVisibility = true
 
             do {
-
-                let _: SdkSetNetworkRankingPublicResult = try await withCheckedThrowingContinuation
-                { [weak self] continuation in
-
-                    guard let self = self else { return }
-
-                    let callback = SetLeaderboardVisibilityCallback { result, err in
-
-                        if let err = err {
-                            continuation.resume(throwing: err)
-                            return
-                        }
-
-                        if let err = result?.error {
-                            continuation.resume(
-                                throwing: LeaderboardError.resultError(message: err.message))
-                            return
-                        }
-
-                        guard let result = result else {
-                            continuation.resume(throwing: LeaderboardError.resultEmpty)
-                            return
-                        }
-
-                        continuation.resume(returning: result)
-
-                    }
-
-                    let args = SdkSetNetworkRankingPublicArgs()
-                    args.isPublic = isPublic
-
-                    api.setNetworkLeaderboardPublic(args, callback: callback)
-
-                }
+                
+                try await urApiService.setNetworkRankingPublic(isPublic)
                 
                 let _ = await self.getLeaderboard()
 
@@ -297,89 +144,3 @@ extension LeaderboardView {
 
 }
 
-private class GetLeaderboardCallback: SdkCallback<
-    SdkLeaderboardResult, SdkGetLeaderboardCallbackProtocol
->, SdkGetLeaderboardCallbackProtocol
-{
-    func result(_ result: SdkLeaderboardResult?, err: Error?) {
-        handleResult(result, err: err)
-    }
-}
-
-private class GetNetworkRankingCallback: SdkCallback<
-    SdkGetNetworkRankingResult, SdkGetNetworkLeaderboardRankingCallbackProtocol
->, SdkGetNetworkLeaderboardRankingCallbackProtocol
-{
-    func result(_ result: SdkGetNetworkRankingResult?, err: Error?) {
-        handleResult(result, err: err)
-    }
-}
-
-private class SetLeaderboardVisibilityCallback: SdkCallback<
-    SdkSetNetworkRankingPublicResult, SdkSetNetworkLeaderboardPublicCallbackProtocol
->, SdkSetNetworkLeaderboardPublicCallbackProtocol
-{
-    func result(_ result: SdkSetNetworkRankingPublicResult?, err: Error?) {
-        handleResult(result, err: err)
-    }
-}
-
-enum LeaderboardError: Error {
-    case isLoading
-    case resultError(message: String)
-    case resultEmpty
-    case earnersEmpty
-    case unknown
-}
-
-enum NetworkRankingError: Error {
-    case isLoading
-    case resultError(message: String)
-    case resultEmpty
-    case unknown
-}
-
-enum SetRankingVisibilityError: Error {
-    case isLoading
-    case resultError(message: String)
-    case resultEmpty
-    case unknown
-}
-
-struct LeaderboardEntry: Identifiable {
-    /**
-     * This is used when passing LeaderboardEntry to lists/tables
-     * ID needs to be unique. We're not using networkId, because it's an empty string if the user has their network marked as private.
-     * Instead, we're using their rank, which is unique, from 0-99
-     */
-    let id: String
-    
-    let networkId: String
-    let networkName: String
-    let netProvided: String
-    let rank: String
-    let isPublic: Bool
-
-    init(
-        networkId: String,
-        networkName: String,
-        netProvided: String,
-        rank: Int,
-        isPublic: Bool,
-        containsProfanity: Bool
-    ) {
-
-        self.id = "\(rank)"
-        self.networkId = networkId
-
-        self.networkName = !isPublic
-            ? NSLocalizedString("Private Network", comment: "Network name when privacy is enabled")
-            : containsProfanity
-                ? String(networkName.prefix(1)) + String(repeating: "*", count: networkName.count - 2) + String(networkName.suffix(1))
-                : networkName
-        
-        self.netProvided = netProvided
-        self.rank = "\(rank + 1)"
-        self.isPublic = isPublic
-    }
-}

--- a/app/network/Main/MainView.swift
+++ b/app/network/Main/MainView.swift
@@ -10,8 +10,9 @@ import URnetworkSdk
 
 struct MainView: View {
     
-    var api: SdkApi
-    var device: SdkDeviceRemote
+    let api: SdkApi
+    let urApiService: UrApiServiceProtocol
+    let device: SdkDeviceRemote
     var logout: () -> Void
     // var connectViewController: SdkConnectViewController?
     var welcomeAnimationComplete: Binding<Bool>
@@ -31,6 +32,7 @@ struct MainView: View {
         self.api = api
         self.logout = logout
         self.device = device
+        self.urApiService = UrApiService(api: api)
 //        self.connectViewController = device.openConnectViewController()
         self.welcomeAnimationComplete = welcomeAnimationComplete
         _subscriptionBalanceViewModel = StateObject(wrappedValue: SubscriptionBalanceViewModel(api: api))
@@ -50,12 +52,14 @@ struct MainView: View {
                 #if os(iOS)
                 MainTabView(
                     api: api,
+                    urApiService: urApiService,
                     device: device,
                     logout: self.logout
                 )
                 #elseif os(macOS)
                 MainNavigationSplitView(
                     api: api,
+                    urApiService: urApiService,
                     device: device,
                     logout: self.logout
                 )

--- a/app/network/Shared/Models/LeaderboardEntry.swift
+++ b/app/network/Shared/Models/LeaderboardEntry.swift
@@ -1,0 +1,46 @@
+//
+//  LeaderboardEntry.swift
+//  URnetwork
+//
+//  Created by Stuart Kuentzel on 7/5/25.
+//
+
+import Foundation
+
+struct LeaderboardEntry: Identifiable {
+    /**
+     * This is used when passing LeaderboardEntry to lists/tables
+     * ID needs to be unique. We're not using networkId, because it's an empty string if the user has their network marked as private.
+     * Instead, we're using their rank, which is unique, from 0-99
+     */
+    let id: String
+    
+    let networkId: String
+    let networkName: String
+    let netProvided: String
+    let rank: String
+    let isPublic: Bool
+
+    init(
+        networkId: String,
+        networkName: String,
+        netProvided: String,
+        rank: Int,
+        isPublic: Bool,
+        containsProfanity: Bool
+    ) {
+
+        self.id = "\(rank)"
+        self.networkId = networkId
+
+        self.networkName = !isPublic
+            ? NSLocalizedString("Private Network", comment: "Network name when privacy is enabled")
+            : containsProfanity
+                ? String(networkName.prefix(1)) + String(repeating: "*", count: networkName.count - 2) + String(networkName.suffix(1))
+                : networkName
+        
+        self.netProvided = netProvided
+        self.rank = "\(rank + 1)"
+        self.isPublic = isPublic
+    }
+}

--- a/app/network/Shared/Services/UrApiService/MockUrApiService.swift
+++ b/app/network/Shared/Services/UrApiService/MockUrApiService.swift
@@ -25,4 +25,12 @@ class MockUrApiService: UrApiServiceProtocol {
         return SdkFeedbackSendResult()
     }
     
+    func getAllProviders() async throws -> SdkFilteredLocations {
+        return SdkFilteredLocations()
+    }
+    
+    func searchProviders(_ query: String) async throws -> SdkFilteredLocations {
+        return SdkFilteredLocations()
+    }
+    
 }

--- a/app/network/Shared/Services/UrApiService/MockUrApiService.swift
+++ b/app/network/Shared/Services/UrApiService/MockUrApiService.swift
@@ -21,4 +21,8 @@ class MockUrApiService: UrApiServiceProtocol {
         return
     }
     
+    func sendFeedback(feedback: String, starCount: Int) async throws -> SdkFeedbackSendResult {
+        return SdkFeedbackSendResult()
+    }
+    
 }

--- a/app/network/Shared/Services/UrApiService/MockUrApiService.swift
+++ b/app/network/Shared/Services/UrApiService/MockUrApiService.swift
@@ -1,0 +1,24 @@
+//
+//  MockUrApiService.swift
+//  networkTests
+//
+//  Created by Stuart Kuentzel on 7/5/25.
+//
+
+import Foundation
+import URnetworkSdk
+
+class MockUrApiService: UrApiServiceProtocol {
+    func getLeaderboard() async throws -> [LeaderboardEntry] {
+        return []
+    }
+    
+    func getLeaderboardRanking() async throws -> SdkGetNetworkRankingResult {
+        return SdkGetNetworkRankingResult()
+    }
+    
+    func setNetworkRankingPublic(_ isPublic: Bool) async throws {
+        return
+    }
+    
+}

--- a/app/network/Shared/Services/UrApiService/UrApiService.swift
+++ b/app/network/Shared/Services/UrApiService/UrApiService.swift
@@ -1,0 +1,214 @@
+//
+//  UrApiService.swift
+//  URnetwork
+//
+//  Created by Stuart Kuentzel on 7/5/25.
+//
+
+import Foundation
+import URnetworkSdk
+
+class UrApiService: UrApiServiceProtocol {
+    
+    private let api: SdkApi
+    
+    init(api: SdkApi) {
+        self.api = api
+    }
+        
+}
+
+// MARK - leaderboard
+extension UrApiService {
+    
+    /**
+     * Fetches leaderboard
+     */
+    func getLeaderboard() async throws -> [LeaderboardEntry] {
+        let args = SdkGetLeaderboardArgs()
+        
+        let result: SdkLeaderboardResult = try await withCheckedThrowingContinuation { continuation in
+            let callback = GetLeaderboardCallback { result, err in
+                if let err = err {
+                    continuation.resume(throwing: err)
+                    return
+                }
+                
+                if let err = result?.error {
+                    continuation.resume(
+                        throwing: LeaderboardError.resultError(message: err.message))
+                    return
+                }
+                
+                guard let result = result else {
+                    continuation.resume(throwing: LeaderboardError.resultEmpty)
+                    return
+                }
+                
+                continuation.resume(returning: result)
+            }
+            
+            self.api.getLeaderboard(args, callback: callback)
+        }
+        
+        var earners: [LeaderboardEntry] = []
+        
+        let n = result.earners?.len()
+        
+        guard let n = n else {
+            throw LeaderboardError.earnersEmpty
+        }
+        
+        for i in 0..<n {
+            let earner = result.earners?.get(i)
+            
+            if let earner = earner {
+                earners.append(
+                    LeaderboardEntry(
+                        networkId: earner.networkId,
+                        networkName: earner.networkName,
+                        netProvided: formatMiB(mib: earner.netMiBCount),
+                        rank: i,
+                        isPublic: earner.isPublic,
+                        containsProfanity: earner.containsProfanity
+                    ))
+            }
+        }
+        
+        return earners
+    }
+    
+    /**
+     * Set network ranking public
+     * Networks are by default private in the leaderboard
+     */
+    func setNetworkRankingPublic(_ isPublic: Bool) async throws {
+        
+        let _: SdkSetNetworkRankingPublicResult = try await withCheckedThrowingContinuation { [weak self] continuation in
+
+            guard let self = self else { return }
+
+            let callback = SetLeaderboardVisibilityCallback { result, err in
+
+                if let err = err {
+                    continuation.resume(throwing: err)
+                    return
+                }
+
+                if let err = result?.error {
+                    continuation.resume(
+                        throwing: LeaderboardError.resultError(message: err.message))
+                    return
+                }
+
+                guard let result = result else {
+                    continuation.resume(throwing: LeaderboardError.resultEmpty)
+                    return
+                }
+
+                continuation.resume(returning: result)
+
+            }
+
+            let args = SdkSetNetworkRankingPublicArgs()
+            args.isPublic = isPublic
+
+            api.setNetworkLeaderboardPublic(args, callback: callback)
+
+        }
+    }
+    
+    /**
+     * Get current network ranking
+     */
+    func getLeaderboardRanking() async throws -> SdkGetNetworkRankingResult {
+        
+        return try await withCheckedThrowingContinuation {
+            [weak self] continuation in
+
+            guard let self = self else { return }
+
+            let callback = GetNetworkRankingCallback { result, err in
+
+                if let err = err {
+                    continuation.resume(throwing: err)
+                    return
+                }
+
+                if let err = result?.error {
+                    continuation.resume(
+                        throwing: LeaderboardError.resultError(message: err.message))
+                    return
+                }
+
+                guard let result = result else {
+                    continuation.resume(throwing: LeaderboardError.resultEmpty)
+                    return
+                }
+
+                continuation.resume(returning: result)
+
+            }
+
+            api.getNetworkLeaderboardRanking(callback)
+
+        }
+    }
+    
+}
+
+
+/**
+ * Callback classes
+ */
+private class GetLeaderboardCallback: SdkCallback<
+    SdkLeaderboardResult, SdkGetLeaderboardCallbackProtocol
+>, SdkGetLeaderboardCallbackProtocol
+{
+    func result(_ result: SdkLeaderboardResult?, err: Error?) {
+        handleResult(result, err: err)
+    }
+}
+
+private class SetLeaderboardVisibilityCallback: SdkCallback<
+    SdkSetNetworkRankingPublicResult, SdkSetNetworkLeaderboardPublicCallbackProtocol
+>, SdkSetNetworkLeaderboardPublicCallbackProtocol
+{
+    func result(_ result: SdkSetNetworkRankingPublicResult?, err: Error?) {
+        handleResult(result, err: err)
+    }
+}
+
+private class GetNetworkRankingCallback: SdkCallback<
+    SdkGetNetworkRankingResult, SdkGetNetworkLeaderboardRankingCallbackProtocol
+>, SdkGetNetworkLeaderboardRankingCallbackProtocol
+{
+    func result(_ result: SdkGetNetworkRankingResult?, err: Error?) {
+        handleResult(result, err: err)
+    }
+}
+
+/**
+ * Error enums
+ */
+enum LeaderboardError: Error {
+    case isLoading
+    case resultError(message: String)
+    case resultEmpty
+    case earnersEmpty
+    case unknown
+}
+
+enum NetworkRankingError: Error {
+    case isLoading
+    case resultError(message: String)
+    case resultEmpty
+    case unknown
+}
+
+enum SetRankingVisibilityError: Error {
+    case isLoading
+    case resultError(message: String)
+    case resultEmpty
+    case unknown
+}

--- a/app/network/Shared/Services/UrApiService/UrApiServiceProtocol.swift
+++ b/app/network/Shared/Services/UrApiService/UrApiServiceProtocol.swift
@@ -16,4 +16,9 @@ protocol UrApiServiceProtocol {
     func getLeaderboard() async throws -> [LeaderboardEntry]
     func setNetworkRankingPublic(_ isPublic: Bool) async throws -> Void
     func getLeaderboardRanking() async throws -> SdkGetNetworkRankingResult
+    
+    /**
+     * Feedback
+     */
+    func sendFeedback(feedback: String, starCount: Int) async throws -> SdkFeedbackSendResult
 }

--- a/app/network/Shared/Services/UrApiService/UrApiServiceProtocol.swift
+++ b/app/network/Shared/Services/UrApiService/UrApiServiceProtocol.swift
@@ -21,4 +21,10 @@ protocol UrApiServiceProtocol {
      * Feedback
      */
     func sendFeedback(feedback: String, starCount: Int) async throws -> SdkFeedbackSendResult
+    
+    /**
+     * Provider list
+     */
+    func searchProviders(_ query: String) async throws -> SdkFilteredLocations
+    func getAllProviders() async throws -> SdkFilteredLocations
 }

--- a/app/network/Shared/Services/UrApiService/UrApiServiceProtocol.swift
+++ b/app/network/Shared/Services/UrApiService/UrApiServiceProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  UrApiServiceProtocol.swift
+//  URnetwork
+//
+//  Created by Stuart Kuentzel on 7/5/25.
+//
+
+import Foundation
+import URnetworkSdk
+
+protocol UrApiServiceProtocol {
+    
+    /**
+     * Leaderboard
+     */
+    func getLeaderboard() async throws -> [LeaderboardEntry]
+    func setNetworkRankingPublic(_ isPublic: Bool) async throws -> Void
+    func getLeaderboardRanking() async throws -> SdkGetNetworkRankingResult
+}

--- a/app/network/Shared/Utilities/FormatMiB.swift
+++ b/app/network/Shared/Utilities/FormatMiB.swift
@@ -1,0 +1,42 @@
+//
+//  FormatMiB.swift
+//  URnetwork
+//
+//  Created by Stuart Kuentzel on 7/5/25.
+//
+
+import Foundation
+
+func formatMiB(mib: Float) -> String {
+
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.maximumFractionDigits = 2
+    
+    let pib: Float = 1024 * 1024 * 1024
+    let tib: Float = 1024 * 1024
+    let gib: Float = 1024
+
+    // 1 GiB = 1024 MiB
+    // if mib >= 1_048_576 {  // 1 PiB = 1024 TiB = 1,048,576 GiB
+    if mib >= pib {
+        let pib = mib / pib
+        let formatted =
+            formatter.string(from: NSNumber(value: pib)) ?? String(format: "%.2f", pib)
+        return "\(formatted) PiB"
+    } else if mib >= tib {  // 1 TiB = 1024 GiB = 1,048,576 MiB
+        let tib = mib / tib
+        let formatted =
+            formatter.string(from: NSNumber(value: tib)) ?? String(format: "%.2f", tib)
+        return "\(formatted) TiB"
+    } else if mib >= gib {  // 1 GiB = 1024 MiB
+        let gib = mib / gib
+        let formatted =
+            formatter.string(from: NSNumber(value: gib)) ?? String(format: "%.2f", gib)
+        return "\(formatted) GiB"
+    } else {
+        let formatted =
+            formatter.string(from: NSNumber(value: mib)) ?? String(format: "%.2f", mib)
+        return "\(formatted) MiB"
+    }
+}

--- a/app/network/iOS/Navigation/MainTabView.swift
+++ b/app/network/iOS/Navigation/MainTabView.swift
@@ -65,6 +65,7 @@ struct MainTabView: View {
              */
             ConnectView_iOS(
                 api: api,
+                urApiService: urApiService,
                 logout: logout,
                 device: device,
                 providerListSheetViewModel: providerListSheetViewModel,

--- a/app/network/iOS/Navigation/MainTabView.swift
+++ b/app/network/iOS/Navigation/MainTabView.swift
@@ -131,7 +131,7 @@ struct MainTabView: View {
              * Feedback View
              */
             FeedbackView(
-                api: api
+                urApiService: urApiService
             )
             .background(themeManager.currentTheme.backgroundColor)
             .tabItem {

--- a/app/network/iOS/Navigation/MainTabView.swift
+++ b/app/network/iOS/Navigation/MainTabView.swift
@@ -12,6 +12,7 @@ import URnetworkSdk
 struct MainTabView: View {
     
     var api: SdkApi
+    var urApiService: UrApiServiceProtocol
     var device: SdkDeviceRemote
     var logout: () -> Void
     var connectViewController: SdkConnectViewController?
@@ -29,10 +30,12 @@ struct MainTabView: View {
     
     init(
         api: SdkApi,
+        urApiService: UrApiServiceProtocol,
         device: SdkDeviceRemote,
         logout: @escaping () -> Void
     ) {
         self.api = api
+        self.urApiService = urApiService
         self.logout = logout
         self.device = device
         
@@ -109,7 +112,7 @@ struct MainTabView: View {
              * Leaderboard View
              */
             LeaderboardView(
-                api: api
+                api: urApiService
             )
             .background(themeManager.currentTheme.backgroundColor)
             .tabItem {

--- a/app/network/mac0S/Navigation/MainNavigationSplitView.swift
+++ b/app/network/mac0S/Navigation/MainNavigationSplitView.swift
@@ -130,7 +130,7 @@ struct MainNavigationSplitView: View {
             switch selectedTab {
             case .connect:
                 ConnectView_macOS(
-                    api: api
+                    urApiService: urApiService
                 )
             case .account:
                 AccountNavStackView(

--- a/app/network/mac0S/Navigation/MainNavigationSplitView.swift
+++ b/app/network/mac0S/Navigation/MainNavigationSplitView.swift
@@ -145,7 +145,7 @@ struct MainNavigationSplitView: View {
                 LeaderboardView(api: urApiService)
             case .support:
                 FeedbackView(
-                    api: api
+                    urApiService: urApiService
                 )
                 .background(themeManager.currentTheme.backgroundColor)
                 .tabItem {

--- a/app/network/mac0S/Navigation/MainNavigationSplitView.swift
+++ b/app/network/mac0S/Navigation/MainNavigationSplitView.swift
@@ -23,6 +23,7 @@ struct MainNavigationSplitView: View {
     @State private var selectedTab: MainNavigationTab = .connect
     
     var api: SdkApi
+    let urApiService: UrApiServiceProtocol
     var device: SdkDeviceRemote
     var logout: () -> Void
     
@@ -39,10 +40,12 @@ struct MainNavigationSplitView: View {
     
     init(
         api: SdkApi,
+        urApiService: UrApiServiceProtocol,
         device: SdkDeviceRemote,
         logout: @escaping () -> Void
     ) {
         self.api = api
+        self.urApiService = urApiService
         self.logout = logout
         self.device = device
         
@@ -139,7 +142,7 @@ struct MainNavigationSplitView: View {
                     referralLinkViewModel: referralLinkViewModel
                 )
             case .leaderboard:
-                LeaderboardView(api: api)
+                LeaderboardView(api: urApiService)
             case .support:
                 FeedbackView(
                     api: api


### PR DESCRIPTION
Incrementally migrate from passing the SDK API directly to view models to using the UrApiService.
Allows for passing mocks to previews and testing.