### PR TITLE
Fix Upgrade Prompt

### DIFF
--- a/app/network/Main/Connect/ConnectView-iOS.swift
+++ b/app/network/Main/Connect/ConnectView-iOS.swift
@@ -120,12 +120,21 @@ struct ConnectView_iOS: View {
             
         }
         .onChange(of: connectViewModel.connectionStatus) { newValue in
+            
+            // Cancel any existing banner task
+            connectViewModel.upgradeBannerTask?.cancel()
+            connectViewModel.upgradeBannerTask = nil
+            
             if newValue == .connected && !connectViewModel.showUpgradeBanner && subscriptionBalanceViewModel.currentPlan != .supporter {
                 // Show the banner after 10 seconds when connected
-                Task {
+                connectViewModel.upgradeBannerTask = Task {
                     try? await Task.sleep(for: .seconds(10))
-                    withAnimation {
-                        connectViewModel.showUpgradeBanner = true
+                    // Check if the task was not cancelled before showing the banner
+                    guard !Task.isCancelled else { return }
+                    await MainActor.run {
+                        withAnimation {
+                            connectViewModel.showUpgradeBanner = true
+                        }
                     }
                 }
             } else if newValue != .connected {

--- a/app/network/Shared/ViewModels/ConnectViewModel.swift
+++ b/app/network/Shared/ViewModels/ConnectViewModel.swift
@@ -104,6 +104,7 @@ class ConnectViewModel: ObservableObject {
      */
     @Published var showUpgradeBanner = false
     @Published var isPresentedUpgradeSheet: Bool = false
+    var upgradeBannerTask: Task<Void, Never>? = nil
     
     private var api: SdkApi?
     var device: SdkDeviceRemote?


### PR DESCRIPTION
If the user connect status changes within 10 seconds after connecting, dismiss the upgrade banner launch task.