### PR TITLE
fix(ios): apply custom network change immediately for login wallet/auth flows

### DIFF
--- a/app/network/Authenticate/LoginNavigationView.swift
+++ b/app/network/Authenticate/LoginNavigationView.swift
@@ -18,13 +18,24 @@ struct LoginNavigationView: View {
     @EnvironmentObject var deviceManager: DeviceManager
     
     var api: SdkApi
-    let urApiService: UrApiServiceProtocol
     var cancel: (() -> Void)? = nil
     var handleSuccess: (_ jwt: String) async -> Void
+
+    // Built from a live closure over `deviceManager.api` (an @EnvironmentObject,
+    // not available yet at init time) rather than the `api` snapshot passed
+    // in, so that switching the active network space (Settings > Change
+    // Network API) while this view is on screen is picked up immediately by
+    // every subsequent API call - including wallet-auth challenge/login,
+    // which previously kept hitting the network active when the login flow
+    // was first presented until the app was restarted.
+    private var urApiService: UrApiServiceProtocol {
+        UrApiService(apiProvider: { [weak deviceManager] in
+            deviceManager?.api ?? api
+        })
+    }
     
     init(api: SdkApi, cancel: (() -> Void)? = nil, handleSuccess: @escaping (_ jwt: String) async -> Void) {
         self.api = api
-        self.urApiService = UrApiService(api: api)
         self.cancel = cancel
         self.handleSuccess = handleSuccess
         _guestUpgradeViewModel = StateObject(wrappedValue: GuestUpgradeViewModel(api: api))

--- a/app/network/ContentView.swift
+++ b/app/network/ContentView.swift
@@ -41,6 +41,7 @@ struct ContentView: View {
                         api: api,
                         handleSuccess: handleSuccessWithJwt
                     )
+                    .id(deviceManager.activeHostName)
                     .opacity(opacity)
 
                 case .main:

--- a/app/network/Main/Account/AccountRootView.swift
+++ b/app/network/Main/Account/AccountRootView.swift
@@ -480,6 +480,7 @@ struct AccountRootView: View {
                     }
                 }
             )
+            .id(deviceManager.activeHostName)
         }
         .toolbar {
             ToolbarItem {
@@ -508,6 +509,7 @@ struct AccountRootView: View {
                     }
                 }
             )
+            .id(deviceManager.activeHostName)
             .environmentObject(themeManager)
             .environmentObject(deviceManager)
             .environmentObject(snackbarManager)

--- a/app/network/Main/Connect/ConnectView-iOS.swift
+++ b/app/network/Main/Connect/ConnectView-iOS.swift
@@ -394,6 +394,7 @@ struct ConnectView_iOS: View {
                         }
                     }
                 )
+                .id(deviceManager.activeHostName)
             }
             .onChange(of: connectViewModel.connectionStatus) { _ in
                 checkTunnelStatus()

--- a/app/network/Shared/Services/UrApiService/UrApiService.swift
+++ b/app/network/Shared/Services/UrApiService/UrApiService.swift
@@ -10,12 +10,41 @@ import URnetworkSdk
 
 class UrApiService: UrApiServiceProtocol {
     
-    private let api: SdkApi
+    // Resolved live on every call instead of captured once at init. This
+    // mirrors Android's `application.api` (a `get() = networkSpaceManagerProvider
+    // .getNetworkSpace()?.api` computed property) so that switching the
+    // active network space (Settings > Change Network API) is picked up
+    // immediately by any in-flight or new API call, without needing to
+    // tear down and recreate the whole view hierarchy that holds this
+    // service (which proved unreliable via SwiftUI .id() invalidation).
+    private let apiProvider: () -> SdkApi?
+    private var api: SdkApi? {
+        apiProvider()
+    }
     
     let domain = "UrApiService"
     
+    /// Fixed-api initializer, kept for call sites/tests that already have a
+    /// concrete `SdkApi` and don't need to react to network switches (e.g.
+    /// once a device is fully initialized and logged in, the api rarely
+    /// changes for the lifetime of that screen).
     init(api: SdkApi) {
-        self.api = api
+        self.apiProvider = { api }
+    }
+
+    /// Live-provider initializer. Pass a closure that always resolves the
+    /// current api (e.g. `{ deviceManager.api }`) so this service tracks
+    /// network-space changes made while the view using it is still on
+    /// screen (the login flow, most notably).
+    init(apiProvider: @escaping () -> SdkApi?) {
+        self.apiProvider = apiProvider
+    }
+
+    private func requireApi() throws -> SdkApi {
+        guard let api else {
+            throw NSError(domain: domain, code: -1, userInfo: [NSLocalizedDescriptionKey: "No active network API available"])
+        }
+        return api
     }
 
     private func nonEmptyJwt(_ jwt: String, context: String) -> Result<String, Error> {
@@ -36,6 +65,8 @@ extension UrApiService {
      */
     func getLeaderboard() async throws -> [LeaderboardEntry] {
         let args = SdkGetLeaderboardArgs()
+        
+        let api = try requireApi()
         
         let result: SdkLeaderboardResult = try await withCheckedThrowingContinuation { continuation in
             
@@ -59,7 +90,7 @@ extension UrApiService {
                 continuation.resume(returning: result)
             }
             
-            self.api.getLeaderboard(args, callback: callback)
+            api.getLeaderboard(args, callback: callback)
         }
         
         var earners: [LeaderboardEntry] = []
@@ -94,6 +125,8 @@ extension UrApiService {
      * Networks are by default private in the leaderboard
      */
     func setNetworkRankingPublic(_ isPublic: Bool) async throws {
+        
+        let api = try requireApi()
         
         let _: SdkSetNetworkRankingPublicResult = try await withCheckedThrowingContinuation { continuation in
 
@@ -131,6 +164,8 @@ extension UrApiService {
      * Get current network ranking
      */
     func getLeaderboardRanking() async throws -> SdkGetNetworkRankingResult {
+        
+        let api = try requireApi()
         
         return try await withCheckedThrowingContinuation { continuation in
 
@@ -170,6 +205,7 @@ extension UrApiService {
         feedback: String,
         starCount: Int
     ) async throws -> SdkFeedbackSendResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = SendFeedbackCallback { result, err in
@@ -208,6 +244,7 @@ extension UrApiService {
      * Search providers
      */
     func searchProviders(_ query: String) async throws -> SdkFilteredLocations {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = FindLocationsCallback { result, err in
@@ -239,6 +276,7 @@ extension UrApiService {
      * Get all providers
      */
     func getAllProviders() async throws -> SdkFilteredLocations {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = FindLocationsCallback { result, err in
@@ -270,6 +308,7 @@ extension UrApiService {
 extension UrApiService {
     
     func authLogin(_ args: SdkAuthLoginArgs) async throws -> AuthLoginResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = AuthLoginCallback { result, error in
@@ -357,6 +396,7 @@ extension UrApiService {
     }
     
     func createNetwork(_ args: SdkNetworkCreateArgs) async throws -> LoginNetworkResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = NetworkCreateCallback { result, err in
@@ -402,6 +442,7 @@ extension UrApiService {
     }
     
     func upgradeGuest(_ args: SdkUpgradeGuestArgs) async throws -> LoginNetworkResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = UpgradeGuestCallback { result, err in
@@ -448,6 +489,8 @@ extension UrApiService {
     
     func createAuthCode() async throws -> SdkAuthCodeCreateResult {
         
+        let api = try requireApi()
+        
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = AuthCodeCreateCallback { result, err in
@@ -481,6 +524,7 @@ extension UrApiService {
     }
     
     func authCodeLogin(_ args: SdkAuthCodeLoginArgs) async throws -> SdkAuthCodeLoginResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = AuthCodeLoginCallback { result, err in
@@ -516,6 +560,7 @@ extension UrApiService {
     }
 
     func authWalletChallenge(_ args: SdkAuthWalletChallengeArgs) async throws -> SdkAuthWalletChallengeResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
 
             let callback = AuthWalletChallengeCallback { result, err in
@@ -550,6 +595,7 @@ extension UrApiService {
 extension UrApiService {
     
     func validateReferralCode(_ code: String) async throws -> SdkValidateReferralCodeResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = ValidateReferralCallback { result, err in
@@ -584,6 +630,8 @@ extension UrApiService {
     
     func fetchSubscriptionBalance() async throws -> SdkSubscriptionBalanceResult {
         
+        let api = try requireApi()
+        
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = GetSubscriptionBalanceCallback { result, err in
@@ -608,6 +656,8 @@ extension UrApiService {
     }
     
     func redeemBalanceCode(_ code: String) async throws -> SdkRedeemBalanceCodeResult {
+        
+        let api = try requireApi()
         
         return try await withCheckedThrowingContinuation { continuation in
             
@@ -636,6 +686,7 @@ extension UrApiService {
     }
     
     func getRedeemedBalanceCodes() async throws -> SdkGetNetworkRedeemedBalanceCodesResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = GetNetworkRedeemedBalanceCodesCallback { result, err in
@@ -670,6 +721,8 @@ extension UrApiService {
     
     func blockLocation(_ locationId: SdkId) async throws -> SdkNetworkBlockLocationResult {
         
+        let api = try requireApi()
+        
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = BlockLocationCallback { result, err in
@@ -698,6 +751,8 @@ extension UrApiService {
     
     func unblockLocation(_ locationId: SdkId) async throws -> SdkNetworkUnblockLocationResult {
         
+        let api = try requireApi()
+        
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = UnblockLocationCallback { result, err in
@@ -725,6 +780,8 @@ extension UrApiService {
     }
     
     func getBlockedLocations() async throws -> SdkGetNetworkBlockedLocationsResult {
+        
+        let api = try requireApi()
         
         return try await withCheckedThrowingContinuation { continuation in
             
@@ -756,6 +813,8 @@ extension UrApiService {
     
     func deleteAccount() async throws -> SdkNetworkDeleteResult {
         
+        let api = try requireApi()
+        
         return try await withCheckedThrowingContinuation { continuation in
             
             let callback = NetworkDeleteCallback { result, err in
@@ -782,6 +841,8 @@ extension UrApiService {
     
     func getReferralNetwork() async throws -> SdkGetReferralNetworkResult {
         
+        let api = try requireApi()
+        
         return try await withCheckedThrowingContinuation { continuation in
 
             let callback = GetNetworkReferralCallback { result, err in
@@ -805,6 +866,8 @@ extension UrApiService {
     }
     
     func setNetworkReferral(_ referralCode: String) async throws -> SdkSetNetworkReferralResult {
+        
+        let api = try requireApi()
         
         return try await withCheckedThrowingContinuation { continuation in
 
@@ -833,6 +896,7 @@ extension UrApiService {
     }
     
     func unlinkReferralNetwork() async throws -> SdkUnlinkReferralNetworkResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
 
             let callback = UnlinkReferralNetworkCallback { result, err in
@@ -861,6 +925,8 @@ extension UrApiService {
 extension UrApiService {
     
     func getNetworkReliability() async throws -> SdkGetNetworkReliabilityResult {
+        
+        let api = try requireApi()
         
         return try await withCheckedThrowingContinuation { continuation in
             
@@ -891,6 +957,8 @@ extension UrApiService {
 extension UrApiService {
     
     func validateWalletAddress(address: String, chain: String) async throws -> Bool {
+        
+        let api = try requireApi()
         
         return try await withCheckedThrowingContinuation { continuation in
 
@@ -1160,6 +1228,7 @@ enum UpdateReferralNetworkError: Error {
 extension UrApiService {
 
     func getNetworkClients() async throws -> SdkNetworkClientsResult {
+        let api = try requireApi()
         return try await withCheckedThrowingContinuation { continuation in
 
             let callback = GetNetworkClientsCallback { result, err in
@@ -1183,6 +1252,7 @@ extension UrApiService {
     }
 
     func deviceSetName(deviceId: SdkId, deviceName: String) async throws -> Void {
+        let api = try requireApi()
         let _: SdkDeviceSetNameResult = try await withCheckedThrowingContinuation { continuation in
 
             let args = SdkDeviceSetNameArgs()


### PR DESCRIPTION
## What

Fixes the login-flow **custom Network API** switch on iOS/macOS so Solana and Bittensor wallet logins (and other API-backed login paths) immediately use the newly selected network, instead of staying stuck on the default/old API until the app is restarted.

Verified via manual testing on the fork `beta/custom-server` branch.

## Bug

After using **Change Network API** on the login screen:

1. Auth code login could use the custom network.
2. Solana/Bittensor wallet login kept using the previous/default network.
3. Restarting the app then made *everything* correctly use the custom network.

Android already worked because its `application.api` is always computed live:

```kotlin
val api get() = networkSpaceManagerProvider.getNetworkSpace()?.api
```

iOS captured a single `SdkApi` into `UrApiService` once in `LoginNavigationView.init()` and reused that stale reference after `deviceManager.applyNetworkSpace(...)`.

The earlier approach of only using SwiftUI `.id(deviceManager.activeHostName)` was **not enough** in practice:

- The Network API sheet that calls `applyNetworkSpace(...)` is presented from inside the login view tree.
- Tearing that tree down via `.id(...)` while the sheet is dismiss/applying can race/coalesce, so wallet challenge + login still used the old API.

## Fix

### 1. Live API resolution in `UrApiService` (primary fix)

- Changed `UrApiService` so the active `SdkApi` is resolved on **every call** via an `apiProvider` closure, not stored once at init.
- Kept `init(api:)` for fixed one-shot usage (e.g. main logged-in views).
- Added `init(apiProvider:)` for live network-space tracking.
- Every async API method now does `let api = try requireApi()` and then uses that live resolved client.

### 2. Login flow wires the live provider

- `LoginNavigationView.urApiService` is now a computed property that reads `deviceManager.api` via a weak closure:
  - resolves active network API at call time
  - falls back to the original injected `api` if needed
- This means after Apply on Change Network API, the next wallet challenge / wallet login / auth code call uses the newly active network without an app restart.

### 3. Keep view identity reset as defense-in-depth

Still includes `.id(deviceManager.activeHostName)` on the places that present `LoginNavigationView`:

- `ContentView` (initial login)
- `ConnectView-iOS` (guest upgrade)
- `AccountRootView` (iOS + macOS)

This resets ephemeral login UI state after a network switch while no longer being the sole refresh mechanism.

## Files

- `app/network/Shared/Services/UrApiService/UrApiService.swift`
- `app/network/Authenticate/LoginNavigationView.swift`
- `app/network/ContentView.swift`
- `app/network/Main/Connect/ConnectView-iOS.swift`
- `app/network/Main/Account/AccountRootView.swift`

## Manual test plan

1. Install build from branch.
2. Open login screen.
3. Change Network API to a custom host and hit **Apply**.
4. Confirm UI no longer needs app restart and:
   - Solana login hits the custom network
   - Bittensor login hits the custom network
   - Auth-code login still hits the custom network
5. Switch back to default network and confirm both wallet and auth-code flows follow it again.

## Notes

- Draft PR against `urnetwork/apple` `main`.
- No CI/workflow file changes.
- Pattern intentionally matched to Android's live API getter so both platforms behave the same during login surprising users less.