### PR TITLE
reliability port: developer screen, exit attribution, site pin rules

### DIFF
--- a/app/network/Main/Account/AccountNavStackView.swift
+++ b/app/network/Main/Account/AccountNavStackView.swift
@@ -215,6 +215,12 @@ struct AccountNavStackView: View {
                         .navigationTitle("Provider Identities")
                         .background(themeManager.currentTheme.backgroundColor)
 
+                case .developer:
+
+                    DeveloperView()
+                        .navigationTitle("Developer")
+                        .background(themeManager.currentTheme.backgroundColor)
+
                 }
                 
             }

--- a/app/network/Main/Account/AccountNavStackViewModel.swift
+++ b/app/network/Main/Account/AccountNavStackViewModel.swift
@@ -18,6 +18,7 @@ enum AccountNavigationPath: Hashable {
     case transferBalanceCodes
     case providerContracts
     case providerIdentities
+    case developer
 }
 
 extension AccountNavStackView {

--- a/app/network/Main/Account/Settings/Developer/DeveloperView.swift
+++ b/app/network/Main/Account/Settings/Developer/DeveloperView.swift
@@ -1,0 +1,725 @@
+//
+//  DeveloperView.swift
+//  URnetwork
+//
+//  Created by Claude on 8/4/26.
+//
+
+import SwiftUI
+import URnetworkSdk
+
+/**
+ * Developer tools for diagnosing connection problems.
+ *
+ * Its own screen rather than a section at the bottom of Settings: these
+ * controls act on the live connection while something is going wrong, and the
+ * set is expected to grow. Every control takes effect on the next packet, so
+ * a fix can be switched off and back on *during* a freeze without
+ * reconnecting and destroying the thing being observed.
+ *
+ * The timing controls are values rather than switches because the right value
+ * is not knowable in advance -- how long to wait before giving up on an exit
+ * trades recovery speed against dropping a slow-but-alive one, and that
+ * balance differs per connection. Each edits as a number in the unit the
+ * detail names (milliseconds or a count), with 0 restoring the behaviour that
+ * shipped before the fix it controls so any of them can still be A/B'd.
+ */
+struct DeveloperView: View {
+
+    @EnvironmentObject var themeManager: ThemeManager
+    @EnvironmentObject var reliabilityStore: ReliabilityStore
+
+    /**
+     * non-optional convenience over the published snapshot; the control
+     * sections only render while `reliabilityStore.connected`
+     */
+    private var settings: ReliabilitySettings {
+        reliabilityStore.settings ?? ReliabilitySettings()
+    }
+
+    var body: some View {
+        Form {
+
+            introSection
+
+            if reliabilityStore.connected {
+                measurementsSection
+                detectionSection
+                placementSection
+                recoverySection
+                probingSection
+                observabilitySection
+                exitsSection
+                actionsSection
+            }
+
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .background(themeManager.currentTheme.backgroundColor)
+        .onAppear {
+            reliabilityStore.setActive(true)
+        }
+        .onDisappear {
+            reliabilityStore.setActive(false)
+        }
+    }
+
+    // MARK: - Sections
+
+    private var introSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Tools for diagnosing connection freezes. These act on the live connection.")
+                    .font(themeManager.currentTheme.secondaryBodyFont)
+                    .foregroundColor(themeManager.currentTheme.textMutedColor)
+
+                if !reliabilityStore.connected {
+                    Text("Connect to use these tools.")
+                        .font(themeManager.currentTheme.bodyFont)
+                        .foregroundColor(themeManager.currentTheme.textColor)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    /**
+     * Measurements come first because they are what the rest of this screen
+     * is for. Reliability changes have been judged on how long a freeze felt,
+     * which is why fixes that were correct in isolation changed nothing in
+     * use. A candidate that does not move blast radius or recovery time did
+     * not work, however good the reasoning behind it was.
+     */
+    private var measurementsSection: some View {
+        Section {
+            let metrics = reliabilityStore.metrics ?? ReliabilityMetrics()
+
+            Group {
+                metricRow(
+                    "Flows opened",
+                    "Total since reset, so runs of different lengths compare",
+                    value: "\(metrics.flowsOpened)"
+                )
+                // dial failures are independent of exit-loss events -- a
+                // re-raced flow is one that did NOT cost an exit removal -- so
+                // these stay always-shown beside flows opened rather than
+                // behind the exit-loss guard below
+                metricRow(
+                    "Provider connect failures",
+                    "Times a provider reported it could not open the upstream connection",
+                    value: "\(metrics.dialFailuresIntercepted)"
+                )
+                metricRow(
+                    "Moved to another exit",
+                    "How many of those failures were quietly moved instead of hanging",
+                    value: "\(metrics.flowsReraced)"
+                )
+                // provider-qualification proof-of-life: sent climbs within
+                // seconds of connecting when the sweep is working. Always
+                // shown -- a zero is itself the measurement when comparing
+                // probe on vs off
+                metricRow(
+                    "Probes",
+                    "Qualification probes this session",
+                    value: "\(metrics.probesSent) sent / \(metrics.probesAnswered) answered"
+                )
+                metricRow(
+                    "Busy probes",
+                    "Liveness pings fired at stalled exits; acquitted ones answered and were kept, the removals the probe prevented",
+                    value: "\(metrics.busyProbesSent) sent / \(metrics.busyProbesAcquitted) acquitted"
+                )
+                metricRow(
+                    "Verdicts held",
+                    "Convictions withheld because the phone's own uplink, not the provider, was silent (uplink / transport)",
+                    value: "\(metrics.verdictsHeldUplinkStale) / \(metrics.verdictsHeldTransportDown)"
+                )
+                if 0 < metrics.removalsDeferred {
+                    metricRow(
+                        "Removals deferred",
+                        "Removals the storm breaker held back after a correlated burst",
+                        value: "\(metrics.removalsDeferred)"
+                    )
+                }
+                // host suspends the pause detector caught -- rare and
+                // device-specific, so shown only once it has fired
+                if 0 < metrics.schedulerPausesDetected {
+                    metricRow(
+                        "Suspends caught",
+                        "Host suspends the detector caught, each one a batch of verdicts held instead of executed on a just-resumed phone",
+                        value: "\(metrics.schedulerPausesDetected)"
+                    )
+                }
+                if 0 < metrics.flowsRebound {
+                    metricRow(
+                        "QUIC flows rebound",
+                        "Flows moved to a warm exit inside a removal; accepted means the server took the path change without a re-dial",
+                        value: "\(metrics.flowsRebound) (\(metrics.rebindsAccepted) accepted / \(metrics.rebindsRedialed) re-dialed)"
+                    )
+                }
+            }
+
+            // the loss numbers are meaningless until something has actually
+            // failed, and showing zeros reads as "nothing is wrong" rather
+            // than "nothing has been measured yet"
+            Group {
+                if metrics.exitLossEvents == 0 {
+                    Text("No provider failures yet.")
+                        .font(themeManager.currentTheme.bodyFont)
+                        .foregroundColor(themeManager.currentTheme.textMutedColor)
+                } else {
+                    metricRow(
+                        "Blast radius",
+                        "Connections lost per provider failure. Lower is better",
+                        value: "\(formatBlastRadius(metrics.meanFlowsLostPerExitLoss)) per failure"
+                    )
+                    metricRow(
+                        "Worst single failure",
+                        "The one the user actually feels",
+                        value: "\(metrics.maxFlowsLostInOneEvent) connections"
+                    )
+                    metricRow(
+                        "Recovery time",
+                        "From an exit dying to that site answering again",
+                        value: "avg \(formatDurationMillis(metrics.recoveryMeanMillis)), worst \(formatDurationMillis(metrics.recoveryMaxMillis))"
+                    )
+                    // read together with recovery time: a change that abandons
+                    // flows instead of recovering them makes the average look
+                    // better while this climbs
+                    metricRow(
+                        "Never came back",
+                        "Sites abandoned rather than recovered",
+                        value: "\(metrics.recoveryMissed) of \(metrics.flowsLostToExit)"
+                    )
+                }
+            }
+
+            actionRow("Reset measurements") {
+                reliabilityStore.resetMetrics()
+            }
+        } header: {
+            sectionHeader("Measurements")
+        } footer: {
+            footerText("What a provider failure costs. Reset, run a test, read back.")
+        }
+    }
+
+    /** Detection: how an exit is judged to be failing, and how fast. */
+    private var detectionSection: some View {
+        Section {
+            millisRow(
+                "Drop stalled exits fast",
+                "How long an exit may stop delivering before it is dropped, in ms. Off waits 30s",
+                millis: settings.sendStallTimeoutMillis
+            ) { $0.sendStallTimeoutMillis = $1 }
+            toggleRow(
+                "Probe stalled exits before dropping",
+                "When an exit stalls, ping it once before convicting. A congested but alive exit answers and keeps its flows; a dead one is still dropped. Off convicts on the stall bar",
+                value: settings.busyProbe
+            ) { $0.busyProbe = $1 }
+            millisRow(
+                "Busy probe wait",
+                "How long the stall probe waits for an answer before convicting, in ms. Off derives half the stall bar",
+                millis: settings.busyProbeBudgetMillis
+            ) { $0.busyProbeBudgetMillis = $1 }
+            millisRow(
+                "Suspend detector",
+                "How much timer overshoot reads as the phone being suspended rather than an exit stalling, in ms, so a resumed phone does not convict every exit at once. Off disables it",
+                millis: settings.schedulerPauseToleranceMillis
+            ) { $0.schedulerPauseToleranceMillis = $1 }
+            millisRow(
+                "Suspend recovery window",
+                "How long verdicts stay held after a detected suspend, in ms, giving transports time to re-register. Off uses the built-in 5s",
+                millis: settings.schedulerPauseRecoveryTimeoutMillis
+            ) { $0.schedulerPauseRecoveryTimeoutMillis = $1 }
+            millisRow(
+                "Cut dead connects early",
+                "Drop an exit that has established nothing sooner when two sibling exits are receiving, in ms. Off waits the full 30s connect bar",
+                millis: settings.blackholeConnectComparativeTimeoutMillis
+            ) { $0.blackholeConnectComparativeTimeoutMillis = $1 }
+            millisRow(
+                "Keep quiet providers longer",
+                "How long a provider still acknowledging traffic may return nothing before it is dropped, in ms. Off keeps them until they stop acknowledging",
+                millis: settings.blackholeReceiveTimeoutMillis
+            ) { $0.blackholeReceiveTimeoutMillis = $1 }
+            toggleRow(
+                "Demote before removing",
+                "Ambiguous verdicts bench an exit instead of tearing down its flows; removal needs sustained evidence or an empty exit",
+                value: settings.softVerdictDemote
+            ) { $0.softVerdictDemote = $1 }
+        } header: {
+            sectionHeader("Detection")
+        }
+    }
+
+    /** Placement: which exit a flow lands on, and how the pool is shaped. */
+    private var placementSection: some View {
+        Section {
+            Group {
+                toggleRow(
+                    "Live tier demotion",
+                    "Failing dials and survived verdicts push a provider down the ranking within a second; promotion back needs clean minutes and a proven connect",
+                    value: settings.effectiveTierSelection
+                ) { $0.effectiveTierSelection = $1 }
+                countRow(
+                    "Max connections per exit",
+                    "Losing an exit kills every connection on it. Lower spreads the damage; a site may then use more than one exit IP",
+                    count: settings.maxFlowsPerExit,
+                    zeroLabel: "Unlimited"
+                ) { $0.maxFlowsPerExit = $1 }
+                toggleRow(
+                    "Sticky site affinity",
+                    "A site's new connections stay on the exit its earlier ones already use, even past the flow cap, so a busy site keeps one egress IP. The cap still limits which exits collect new sites. Off restores the strict cap",
+                    value: settings.affinityStickyPastCap
+                ) { $0.affinityStickyPastCap = $1 }
+                toggleRow(
+                    "Follow benched exits",
+                    "A quarantined exit keeps its own sites' new connections through the early bench, when the verdict is least proven, so a bench does not split the site's egress IP. New sites still avoid it. Off scatters them",
+                    value: settings.quarantineGroupFollow
+                ) { $0.quarantineGroupFollow = $1 }
+                millisRow(
+                    "Follow window",
+                    "How long into a bench a site's new connections keep following their exit, in ms — early benches are usually false alarms; one that lasts is trending toward removal and stops collecting flows. Off scatters immediately",
+                    millis: settings.groupFollowWindowMillis
+                ) { $0.groupFollowWindowMillis = $1 }
+                countRow(
+                    "Removal storm limit",
+                    "How many verdict removals are allowed per window before the rest are deferred; a burst is more likely one local cause than many failures. Off removes without limit",
+                    count: settings.removalBudgetCount,
+                    zeroLabel: "Off"
+                ) { $0.removalBudgetCount = $1 }
+                millisRow(
+                    "Removal storm window",
+                    "The window the removal limit is counted over, in ms. Off (like a limit of 0) turns the breaker off",
+                    millis: settings.removalBudgetWindowMillis
+                ) { $0.removalBudgetWindowMillis = $1 }
+            }
+            Group {
+                toggleRow(
+                    "Keep a spare exit warm",
+                    "Size each window one exit beyond its target so a replacement is already connected. Off waits until a loss to backfill",
+                    value: settings.standingReserve
+                ) { $0.standingReserve = $1 }
+                countRow(
+                    "Load corroboration",
+                    "Extra silent destinations required per this many flows before a busy exit can be benched on soft evidence: a 24-flow exit at 8 needs 3 silent sites, not 2. Off keeps the flat minimum",
+                    count: settings.blackholeLoadCorroboration,
+                    zeroLabel: "Off"
+                ) { $0.blackholeLoadCorroboration = $1 }
+                countRow(
+                    "Corroborate silent exits",
+                    "How many distinct destinations must be silent before an exit is convicted on no-receive, so one dead site cannot remove a working exit. Off lets a single destination convict",
+                    count: settings.minBlackholeDestinations,
+                    zeroLabel: "Off"
+                ) { $0.minBlackholeDestinations = $1 }
+                toggleRow(
+                    "Group IPs by site",
+                    "Keeps a site on one exit when its hostname is not visible",
+                    value: settings.clusterAffinityFallback
+                ) { $0.clusterAffinityFallback = $1 }
+                toggleRow(
+                    "Converge late-named flows",
+                    "Moves later connections onto the exit the first one already uses",
+                    value: settings.serverNameAffinityBridge
+                ) { $0.serverNameAffinityBridge = $1 }
+            }
+        } header: {
+            sectionHeader("Placement")
+        }
+    }
+
+    /**
+     * Recovery: getting a flow moving again after its exit fails or the
+     * phone's own network changes underneath it.
+     */
+    private var recoverySection: some View {
+        Section {
+            toggleRow(
+                "Rebind QUIC on exit loss",
+                "Re-pin established QUIC flows to a live exit inside the removal instead of tearing them down",
+                value: settings.quicRebindOnExitLoss
+            ) { $0.quicRebindOnExitLoss = $1 }
+            toggleRow(
+                "Retry refused connects elsewhere",
+                "When a provider can't reach a site, move the connection to another exit instead of letting it hang",
+                value: settings.dialFailureRerace
+            ) { $0.dialFailureRerace = $1 }
+            toggleRow(
+                "Signal UDP teardown",
+                "Tells DNS and QUIC the path is gone instead of going silent",
+                value: settings.udpTeardownSignal
+            ) { $0.udpTeardownSignal = $1 }
+            millisRow(
+                "Release stuck retransmits",
+                "How long retransmits are held before one is released, in ms. Off waits 30s",
+                millis: settings.tcpCollapseMaxHoldMillis
+            ) { $0.tcpCollapseMaxHoldMillis = $1 }
+            millisRow(
+                "Longer TCP idle timeout",
+                "How long a TCP connection may sit idle, in ms. Off uses the UDP bound",
+                millis: settings.tcpSequenceIdleTimeoutMillis
+            ) { $0.tcpSequenceIdleTimeoutMillis = $1 }
+            millisRow(
+                "UDP idle timeout",
+                "How long a non-TCP flow may sit idle before it is reaped, in ms",
+                millis: settings.sequenceIdleTimeoutMillis
+            ) { $0.sequenceIdleTimeoutMillis = $1 }
+            millisRow(
+                "Uplink silence gate",
+                "How long the whole tunnel may be silent before provider verdicts are held as inadmissible, in ms. 0 convicts as before",
+                millis: settings.uplinkStalenessGateMillis
+            ) { $0.uplinkStalenessGateMillis = $1 }
+            millisRow(
+                "Fast first-exit poll",
+                "How often a connecting flow re-checks an empty window, in ms, so the first request leaves right after the first exit lands. Off waits the 2s retry pace",
+                millis: settings.formationPollTimeoutMillis
+            ) { $0.formationPollTimeoutMillis = $1 }
+        } header: {
+            sectionHeader("Recovery")
+        }
+    }
+
+    /** Probing: proving an exit can actually reach real destinations. */
+    private var probingSection: some View {
+        Section {
+            toggleRow(
+                "Probe providers",
+                "Qualify exits by dialing real sites through them. An answer proves the exit; silence never counts against it",
+                value: settings.providerProbe
+            ) { $0.providerProbe = $1 }
+            millisRow(
+                "Probe wait",
+                "How long a qualification probe waits for an answer, in ms. Off uses the built-in 4s. It only bounds waiting for proof, it never convicts",
+                millis: settings.probeTimeoutMillis
+            ) { $0.probeTimeoutMillis = $1 }
+            countRow(
+                "Probe hosts per pass",
+                "How many health sites one qualification pass dials through an exit. 0 probes the entire embedded list; a smaller number rotates through it in blocks",
+                count: settings.probeSampleHostCount,
+                zeroLabel: "All"
+            ) { $0.probeSampleHostCount = $1 }
+            countRow(
+                "Candidates evaluated per slot",
+                "How many providers a window expansion pings and ranks per slot it needs, keeping the best. 1 evaluates exactly what it needs",
+                count: settings.evaluationPoolMultiple,
+                zeroLabel: "0"
+            ) { $0.evaluationPoolMultiple = $1 }
+            actionRow("Probe all exits now") {
+                reliabilityStore.probeAllExits()
+            }
+        } header: {
+            sectionHeader("Probing")
+        }
+    }
+
+    /** Observability: what the session writes to the log for later forensics. */
+    private var observabilitySection: some View {
+        Section {
+            millisRow(
+                "State heartbeat",
+                "How often one line summarizing live state is written to the log for later forensics, in ms. Off silences it; shorter spots a transition, longer keeps more buffer",
+                millis: settings.heartbeatIntervalMillis
+            ) { $0.heartbeatIntervalMillis = $1 }
+            actionRow("Reset to shipped defaults") {
+                reliabilityStore.resetSettings()
+            }
+        } header: {
+            sectionHeader("Observability")
+        }
+    }
+
+    /**
+     * Exit readout. A site split across exits shows up as flows spread over
+     * several rows instead of collected on one.
+     */
+    private var exitsSection: some View {
+        Section {
+            if reliabilityStore.exits.isEmpty {
+                Text("No exits. Connect first.")
+                    .font(themeManager.currentTheme.bodyFont)
+                    .foregroundColor(themeManager.currentTheme.textMutedColor)
+            } else {
+                ForEach(reliabilityStore.exits) { exit in
+                    exitRow(exit)
+                }
+            }
+        } header: {
+            sectionHeader("Exits")
+        }
+    }
+
+    private var actionsSection: some View {
+        Section {
+            actionRow("Refresh") {
+                reliabilityStore.refresh()
+            }
+            // fires the same process-wide network-change path a real
+            // wifi-to-cellular migration triggers, so the uplink-gate storm
+            // drill is one tap instead of physically moving between networks
+            actionRow("Simulate network change") {
+                reliabilityStore.simulateNetworkChange()
+            }
+            if let lastAction = reliabilityStore.lastAction {
+                Text(lastAction)
+                    .font(themeManager.currentTheme.secondaryBodyFont)
+                    .foregroundColor(themeManager.currentTheme.textMutedColor)
+            }
+        }
+    }
+
+    // MARK: - Rows
+
+    private func rowLabel(_ title: LocalizedStringKey, _ detail: LocalizedStringKey) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(themeManager.currentTheme.bodyFont)
+                .foregroundColor(themeManager.currentTheme.textColor)
+            Text(detail)
+                .font(themeManager.currentTheme.secondaryBodyFont)
+                .foregroundColor(themeManager.currentTheme.textMutedColor)
+        }
+    }
+
+    private func sectionHeader(_ text: LocalizedStringKey) -> some View {
+        Text(text)
+            .font(themeManager.currentTheme.secondaryBodyFont)
+            .foregroundColor(themeManager.currentTheme.textMutedColor)
+            .textCase(nil)
+    }
+
+    private func footerText(_ text: LocalizedStringKey) -> some View {
+        Text(text)
+            .font(themeManager.currentTheme.secondaryBodyFont)
+            .foregroundColor(themeManager.currentTheme.textFaintColor)
+    }
+
+    /** A read-only counter row: label and detail with a value in place of a control. */
+    private func metricRow(
+        _ title: LocalizedStringKey,
+        _ detail: LocalizedStringKey,
+        value: String
+    ) -> some View {
+        HStack(alignment: .top) {
+            rowLabel(title, detail)
+            Spacer()
+            Text(value)
+                .font(themeManager.currentTheme.secondaryBodyFont)
+                .foregroundColor(themeManager.currentTheme.textMutedColor)
+        }
+    }
+
+    /**
+     * A bool knob. The write goes through the store's read-modify-write of
+     * the full settings struct against a fresh device read -- the binding's
+     * displayed value is never what gets written back.
+     */
+    private func toggleRow(
+        _ title: LocalizedStringKey,
+        _ detail: LocalizedStringKey,
+        value: Bool,
+        set: @escaping (SdkReliabilitySettings, Bool) -> Void
+    ) -> some View {
+        UrSwitchToggle(
+            isOn: Binding(
+                get: { value },
+                set: { newValue in
+                    reliabilityStore.updateSettings { settings in
+                        set(settings, newValue)
+                    }
+                }
+            ),
+            isEnabled: reliabilityStore.connected
+        ) {
+            rowLabel(title, detail)
+        }
+    }
+
+    /** A duration knob, edited in whole milliseconds. */
+    private func millisRow(
+        _ title: LocalizedStringKey,
+        _ detail: LocalizedStringKey,
+        millis: Int64,
+        set: @escaping (SdkReliabilitySettings, Int64) -> Void
+    ) -> some View {
+        DeveloperNumberRow(
+            title: title,
+            detail: detail,
+            value: millis,
+            display: { formatDurationMillis($0) },
+            enabled: reliabilityStore.connected
+        ) { newValue in
+            reliabilityStore.updateSettings { settings in
+                set(settings, newValue)
+            }
+        }
+    }
+
+    /** A count knob. What 0 means differs per knob, so its label is caller-supplied. */
+    private func countRow(
+        _ title: LocalizedStringKey,
+        _ detail: LocalizedStringKey,
+        count: Int32,
+        zeroLabel: String,
+        set: @escaping (SdkReliabilitySettings, Int32) -> Void
+    ) -> some View {
+        DeveloperNumberRow(
+            title: title,
+            detail: detail,
+            value: Int64(count),
+            display: { $0 <= 0 ? zeroLabel : "\($0)" },
+            enabled: reliabilityStore.connected
+        ) { newValue in
+            reliabilityStore.updateSettings { settings in
+                set(settings, Int32(clamping: newValue))
+            }
+        }
+    }
+
+    private func exitRow(_ exit: ReliabilityExit) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(exit.label)
+                    .font(.system(size: 14).monospaced())
+                    .foregroundColor(themeManager.currentTheme.textColor)
+                Spacer()
+                Text("\(exit.flowCount) flows")
+                    .font(themeManager.currentTheme.secondaryBodyFont)
+                    .foregroundColor(themeManager.currentTheme.textMutedColor)
+            }
+
+            Text(exit.stateLine)
+                .font(themeManager.currentTheme.secondaryBodyFont)
+                .foregroundColor(themeManager.currentTheme.textMutedColor)
+
+            // shown only when the exit has reported upstream dials it could
+            // not open in the recent window -- the out-of-capacity signal the
+            // re-race acts on
+            if 0 < exit.dialFailureCount {
+                Text("\(exit.dialFailureCount) failed dials")
+                    .font(themeManager.currentTheme.secondaryBodyFont)
+                    .foregroundColor(themeManager.currentTheme.textMutedColor)
+            }
+
+            HStack(spacing: 24) {
+                Button("Probe") {
+                    reliabilityStore.probeExit(exit)
+                }
+                Button("Migrate") {
+                    reliabilityStore.migrateExit(exit)
+                }
+            }
+            // borderless so the two buttons hit-test separately instead of
+            // the whole form row swallowing both taps
+            .buttonStyle(.borderless)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/**
+ * A numeric setting edited as a text field, with the formatted effective
+ * value beside it. The committed value goes through the store's
+ * read-modify-write, and the field re-seeds from the device's effective value
+ * on every refresh unless it is being edited.
+ */
+private struct DeveloperNumberRow: View {
+
+    @EnvironmentObject var themeManager: ThemeManager
+
+    let title: LocalizedStringKey
+    let detail: LocalizedStringKey
+    let value: Int64
+    let display: (Int64) -> String
+    let enabled: Bool
+    let commit: (Int64) -> Void
+
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(title)
+                    .font(themeManager.currentTheme.bodyFont)
+                    .foregroundColor(themeManager.currentTheme.textColor)
+
+                Spacer()
+
+                Text(display(value))
+                    .font(themeManager.currentTheme.secondaryBodyFont)
+                    .foregroundColor(themeManager.currentTheme.accentColor)
+
+                TextField("0", text: $text)
+                    .font(.system(size: 13).monospacedDigit())
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 80)
+                    .textFieldStyle(.plain)
+                    .autocorrectionDisabled()
+                    #if os(iOS)
+                    .keyboardType(.numberPad)
+                    #endif
+                    .focused($focused)
+                    .onSubmit {
+                        commitText()
+                    }
+                    .disabled(!enabled)
+            }
+
+            Text(detail)
+                .font(themeManager.currentTheme.secondaryBodyFont)
+                .foregroundColor(themeManager.currentTheme.textMutedColor)
+        }
+        .onAppear {
+            text = "\(value)"
+        }
+        .onChange(of: value) { newValue in
+            if !focused {
+                text = "\(newValue)"
+            }
+        }
+        .onChange(of: focused) { isFocused in
+            if !isFocused {
+                commitText()
+            }
+        }
+    }
+
+    private func commitText() {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard let newValue = Int64(trimmed), 0 <= newValue else {
+            // not a value; restore the effective one
+            text = "\(value)"
+            return
+        }
+        if newValue != value {
+            commit(newValue)
+        }
+    }
+}
+
+/** 0 reads as "Off"; sub-second as ms; otherwise seconds or minutes. */
+private func formatDurationMillis(_ millis: Int64) -> String {
+    if millis <= 0 {
+        return "Off"
+    }
+    if millis < 1000 {
+        return "\(millis)ms"
+    }
+    if millis < 60_000 {
+        let seconds = Double(millis) / 1000.0
+        if seconds == seconds.rounded(.down) {
+            return "\(Int64(seconds))s"
+        }
+        return "\(seconds)s"
+    }
+    return "\(millis / 60_000)m"
+}
+
+/**
+ * Blast radius is a ratio, not a count -- 4.0 connections per failure is a
+ * different claim from 4 -- so it keeps one decimal rather than rounding to
+ * an integer that would hide a change between, say, 4.0 and 4.4.
+ */
+private func formatBlastRadius(_ value: Double) -> String {
+    String(format: "%.1f", value)
+}

--- a/app/network/Main/Account/Settings/Developer/DeveloperView.swift
+++ b/app/network/Main/Account/Settings/Developer/DeveloperView.swift
@@ -28,10 +28,13 @@ struct DeveloperView: View {
 
     @EnvironmentObject var themeManager: ThemeManager
     @EnvironmentObject var reliabilityStore: ReliabilityStore
+    @Environment(\.presentationActive) private var presentationActive
 
     /**
-     * non-optional convenience over the published snapshot; the control
-     * sections only render while `reliabilityStore.connected`
+     * non-optional convenience over the published snapshot. Only ever read
+     * inside the `reliabilityStore.connected` branch, where the snapshot is
+     * non-nil by definition -- the fallback is a compile-time convenience,
+     * never a set of defaults presented as if they were in force.
      */
     private var settings: ReliabilitySettings {
         reliabilityStore.settings ?? ReliabilitySettings()
@@ -57,8 +60,15 @@ struct DeveloperView: View {
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)
         .background(themeManager.currentTheme.backgroundColor)
+        // the 5s poll is an rpc into the packet tunnel extension: it runs only
+        // while this screen is both on screen AND the app is presenting
+        // (backgrounded app / hidden macOS window stops it), the same
+        // three-part lifecycle the rest of the app uses
         .onAppear {
-            reliabilityStore.setActive(true)
+            reliabilityStore.setActive(presentationActive)
+        }
+        .onChange(of: presentationActive) { active in
+            reliabilityStore.setActive(active)
         }
         .onDisappear {
             reliabilityStore.setActive(false)
@@ -399,10 +409,18 @@ struct DeveloperView: View {
                 zeroLabel: "All"
             ) { $0.probeSampleHostCount = $1 }
             countRow(
+                "Probe silence streak",
+                "How many consecutive probe passes an exit may answer with total silence before it is warned out of new-flow placement — the compensation for providers that leave the network mid-session. Placement only: removal stays traffic-based, and any sign of life clears the streak",
+                count: settings.probeSilenceWarnStreak,
+                zeroLabel: "Off"
+            ) { $0.probeSilenceWarnStreak = $1 }
+            countRow(
                 "Candidates evaluated per slot",
                 "How many providers a window expansion pings and ranks per slot it needs, keeping the best. 1 evaluates exactly what it needs",
                 count: settings.evaluationPoolMultiple,
-                zeroLabel: "0"
+                // 0 is not a behaviour: connect clamps this to max(1, …), so
+                // the row says what a 0 actually does rather than showing it
+                zeroLabel: "1 (min)"
             ) { $0.evaluationPoolMultiple = $1 }
             actionRow("Probe all exits now") {
                 reliabilityStore.probeAllExits()
@@ -464,6 +482,11 @@ struct DeveloperView: View {
                     .font(themeManager.currentTheme.secondaryBodyFont)
                     .foregroundColor(themeManager.currentTheme.textMutedColor)
             }
+        } footer: {
+            // every action returns void over the bridge and no-ops when the
+            // extension has no multi client, so the log above records what was
+            // asked for. The counters and exit rows are where it is confirmed
+            footerText("Actions are requests: confirm them in the measurements and exit rows, which refresh underneath.")
         }
     }
 
@@ -491,6 +514,23 @@ struct DeveloperView: View {
         Text(text)
             .font(themeManager.currentTheme.secondaryBodyFont)
             .foregroundColor(themeManager.currentTheme.textFaintColor)
+    }
+
+    /**
+     * A tappable action, rendered as accent-colored text like the android
+     * screen's actions rather than a bordered button.
+     */
+    private func actionRow(_ title: LocalizedStringKey, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .font(themeManager.currentTheme.bodyFont)
+                    .foregroundColor(themeManager.currentTheme.accentColor)
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
     /** A read-only counter row: label and detail with a value in place of a control. */
@@ -649,17 +689,32 @@ private struct DeveloperNumberRow: View {
                 TextField("0", text: $text)
                     .font(.system(size: 13).monospacedDigit())
                     .multilineTextAlignment(.trailing)
-                    .frame(width: 80)
+                    .frame(width: 72)
                     .textFieldStyle(.plain)
                     .autocorrectionDisabled()
+                    // numbersAndPunctuation, NOT numberPad: the number pad has
+                    // no return key, which leaves onSubmit dead and a tap on
+                    // some other field the only way to commit. Non-numeric
+                    // input is rejected by commitText
                     #if os(iOS)
-                    .keyboardType(.numberPad)
+                    .keyboardType(.numbersAndPunctuation)
+                    .submitLabel(.done)
                     #endif
                     .focused($focused)
                     .onSubmit {
-                        commitText()
+                        endEditing()
                     }
                     .disabled(!enabled)
+
+                // the second commit affordance: a form row gives the keyboard
+                // nowhere to go, so editing must be endable from the row itself
+                if focused {
+                    Button("Set") {
+                        endEditing()
+                    }
+                    .font(themeManager.currentTheme.secondaryBodyFont)
+                    .buttonStyle(.borderless)
+                }
             }
 
             Text(detail)
@@ -670,6 +725,9 @@ private struct DeveloperNumberRow: View {
             text = "\(value)"
         }
         .onChange(of: value) { newValue in
+            // never fight the typist: the effective value re-seeds the field
+            // only while it is not being edited, so a poll landing mid-edit
+            // cannot overwrite what is being typed
             if !focused {
                 text = "\(newValue)"
             }
@@ -679,6 +737,17 @@ private struct DeveloperNumberRow: View {
                 commitText()
             }
         }
+    }
+
+    /**
+     * Ends editing through the focus change, so `commitText` runs exactly
+     * once no matter which affordance was used.
+     */
+    private func endEditing() {
+        focused = false
+        #if canImport(UIKit)
+        hideKeyboard()
+        #endif
     }
 
     private func commitText() {

--- a/app/network/Main/Account/Settings/Developer/DeveloperView.swift
+++ b/app/network/Main/Account/Settings/Developer/DeveloperView.swift
@@ -600,16 +600,13 @@ struct DeveloperView: View {
                     .foregroundColor(themeManager.currentTheme.textMutedColor)
             }
 
-            HStack(spacing: 24) {
-                Button("Probe") {
-                    reliabilityStore.probeExit(exit)
-                }
-                Button("Migrate") {
-                    reliabilityStore.migrateExit(exit)
-                }
+            // migrate is the only per-exit action: probing is a full sweep
+            // (see the Probing section), matching the android screen
+            Button("Migrate") {
+                reliabilityStore.migrateExit(exit)
             }
-            // borderless so the two buttons hit-test separately instead of
-            // the whole form row swallowing both taps
+            // borderless so the button hit-tests on its own instead of the
+            // whole form row swallowing the tap
             .buttonStyle(.borderless)
         }
         .padding(.vertical, 2)

--- a/app/network/Main/Account/Settings/SettingsForm-iOS.swift
+++ b/app/network/Main/Account/Settings/SettingsForm-iOS.swift
@@ -429,8 +429,22 @@ struct SettingsForm_iOS: View {
                         .foregroundColor(themeManager.currentTheme.textMutedColor)
                 }
             }
-            
-            
+
+            Section("Developer") {
+                HStack {
+                    Text("Open developer tools")
+                        .font(themeManager.currentTheme.bodyFont)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(themeManager.currentTheme.textMutedColor)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    navigate(.developer)
+                }
+            }
+
+
             Section("Danger") {
                 Button(role: .destructive, action: {
                     presentDeleteAccountConfirmation()

--- a/app/network/Main/Account/Settings/SettingsForm-macOS.swift
+++ b/app/network/Main/Account/Settings/SettingsForm-macOS.swift
@@ -573,7 +573,7 @@ struct SettingsForm_macOS: View {
 
                     
                     Spacer().frame(height: 32)
-
+                    
                     /**
                      * Developer
                      */
@@ -603,7 +603,7 @@ struct SettingsForm_macOS: View {
 
                     HStack {
                         UrLabel(text: "Version and Build info")
-
+                        
                         Spacer()
                     }
                     

--- a/app/network/Main/Account/Settings/SettingsForm-macOS.swift
+++ b/app/network/Main/Account/Settings/SettingsForm-macOS.swift
@@ -573,10 +573,37 @@ struct SettingsForm_macOS: View {
 
                     
                     Spacer().frame(height: 32)
-                    
+
+                    /**
+                     * Developer
+                     */
+                    HStack {
+                        UrLabel(text: "Developer")
+
+                        Spacer()
+                    }
+
+                    HStack {
+                        Text("Open developer tools")
+                            .font(themeManager.currentTheme.bodyFont)
+                            .foregroundColor(themeManager.currentTheme.textColor)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(themeManager.currentTheme.textMutedColor)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        navigate(.developer)
+                    }
+                    .padding()
+                    .background(themeManager.currentTheme.tintedBackgroundBase)
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+                    Spacer().frame(height: 32)
+
                     HStack {
                         UrLabel(text: "Version and Build info")
-                        
+
                         Spacer()
                     }
                     

--- a/app/network/NetworkApp.swift
+++ b/app/network/NetworkApp.swift
@@ -89,6 +89,7 @@ struct NetworkApp: App {
     @StateObject var blockActionsStore = BlockActionsStore()
     @StateObject var dnsSettingsStore = DnsSettingsStore()
     @StateObject var networkPeersStore = NetworkPeersStore()
+    @StateObject var reliabilityStore = ReliabilityStore()
 
     init() {
         let deviceManager = DeviceManager()
@@ -143,6 +144,7 @@ struct NetworkApp: App {
         blockActionsStore.setup(device)
         dnsSettingsStore.setup(device)
         networkPeersStore.setup(device)
+        reliabilityStore.setup(device)
     }
 
     private func resetDeviceStores() {
@@ -150,6 +152,7 @@ struct NetworkApp: App {
         blockActionsStore.reset()
         dnsSettingsStore.reset()
         networkPeersStore.reset()
+        reliabilityStore.reset()
     }
 
     // Cold launch already gets a fresh JWT (the SDK's token manager refreshes
@@ -244,6 +247,7 @@ struct NetworkApp: App {
                 .environmentObject(blockActionsStore)
                 .environmentObject(dnsSettingsStore)
                 .environmentObject(networkPeersStore)
+                .environmentObject(reliabilityStore)
                 .environment(\.presentationActive, presentationLifecycle.isActive)
                 .onOpenURL { url in
                     GIDSignIn.sharedInstance.handle(url)
@@ -287,6 +291,7 @@ struct NetworkApp: App {
                 .environmentObject(blockActionsStore)
                 .environmentObject(dnsSettingsStore)
                 .environmentObject(networkPeersStore)
+                .environmentObject(reliabilityStore)
                 .environment(\.presentationActive, presentationLifecycle.isActive)
                 .onOpenURL { url in
                     GIDSignIn.sharedInstance.handle(url)

--- a/app/network/Shared/ViewModels/BlockActionsStore.swift
+++ b/app/network/Shared/ViewModels/BlockActionsStore.swift
@@ -204,6 +204,10 @@ class BlockActionsStore: ObservableObject {
     // request is never dropped
     private var exitAttributionRefreshing = false
     private var exitAttributionWanted = false
+    // when the last rpc actually went out, for the rate floor in
+    // refreshExitAttribution. Cleared with the rest of the attribution state
+    // so a new device starts fresh rather than inheriting a cooldown.
+    private var exitAttributionLastFetch: Date?
 
     // bumped on every setup/reset so a refresh that started against an old
     // device (or before a reset) can never publish over newer state
@@ -263,6 +267,7 @@ class BlockActionsStore: ObservableObject {
         // later refresh
         exitAttributionRefreshing = false
         exitAttributionWanted = false
+        exitAttributionLastFetch = nil
 
         blockActionsSub?.close()
         blockActionsSub = nil
@@ -374,6 +379,19 @@ class BlockActionsStore: ObservableObject {
             exitAttributionWanted = true
             return
         }
+        // rate floor. Block actions flush on connect's 1s event epoch, so the
+        // event-driven path alone would fire this ~5x the designed rate while
+        // browsing -- and each call walks the whole live-flow table under the
+        // datapath lock on the far side. The periodic tick is already running
+        // at exactly the freshness this feature promises, so a too-soon
+        // request is dropped rather than queued: the next tick, at most
+        // exitAttributionInterval away, does the work.
+        if let last = exitAttributionLastFetch,
+            Date().timeIntervalSince(last) < Self.exitAttributionInterval
+        {
+            return
+        }
+        exitAttributionLastFetch = Date()
         exitAttributionRefreshing = true
         let generation = self.generation
         Task { [weak self] in

--- a/app/network/Shared/ViewModels/BlockActionsStore.swift
+++ b/app/network/Shared/ViewModels/BlockActionsStore.swift
@@ -71,10 +71,14 @@ struct BlockActionItem: Identifiable, Equatable {
  * What a site split rule does with the matching cluster's traffic.
  *
  * EXCLUDED routes the cluster locally, bypassing the tunnel; INCLUDED routes
- * it through the tunnel. PINNED is not routing at all: the cluster stays in
- * the tunnel like any other, but its flows are held to one stable exit, so
- * the site's api and its cdns present a single egress IP -- the fix for
- * sites whose images fail to load behind a multi-exit VPN.
+ * it through the tunnel with no pin. PINNED is not routing at all, and for a
+ * SITE rule it is narrower than the app pinning android also offers: the
+ * cluster keeps its ordinary per-domain grouping and gains only a longer
+ * tolerance for a benched or quarantined exit before its flows are re-raced
+ * off it (sdk `RouteOverride.Pin` -- the affinity-group consolidation that
+ * makes an app's api and cdns share one egress ip is gated on an app id,
+ * which iOS has no way to supply). The site-rule effect is fewer mid-session
+ * exit changes for that site, not one shared egress ip.
  */
 enum SplitRuleMode {
     case excluded
@@ -187,14 +191,29 @@ class BlockActionsStore: ObservableObject {
 
     // the exit-attribution re-poll: flows re-race and rebind between
     // block-action events, so the join is refreshed on a slow tick as well,
-    // active only while a consuming view is visible -- a row growing a
-    // second exit chip mid-session is exactly the observation this feature
-    // exists for
+    // active only while a consuming view is visible AND the app is
+    // presenting it -- a row growing a second exit chip mid-session is
+    // exactly the observation this feature exists for
     private var exitAttributionTimer: Timer?
-    private var exitAttributionActive = false
+    // the consuming view is mounted
+    private var exitAttributionVisible = false
+    // the app is backgrounded, or its window is hidden/occluded
+    private var exitAttributionSuspended = false
+    // one refresh is in flight; `wanted` records a request that arrived
+    // while it was, so the coalescer has a trailing edge and the last
+    // request is never dropped
     private var exitAttributionRefreshing = false
+    private var exitAttributionWanted = false
+
+    // bumped on every setup/reset so a refresh that started against an old
+    // device (or before a reset) can never publish over newer state
+    private var generation = 0
 
     private static let exitAttributionInterval: TimeInterval = 5.0
+
+    private var exitAttributionActive: Bool {
+        exitAttributionVisible && !exitAttributionSuspended
+    }
 
     deinit {
         exitAttributionTimer?.invalidate()
@@ -232,10 +251,19 @@ class BlockActionsStore: ObservableObject {
         updateBlockActions()
         updateBlockStats()
         updateOverrides()
-        refreshExitAttribution()
+        // the view's visibility survives a device swap; pick the poll back up
+        applyExitAttributionActive()
     }
 
     func reset() {
+        generation += 1
+        stopExitAttributionTimer()
+        // the flag belongs to the generation that is ending: an rpc still in
+        // flight can no longer publish, so leaving it set would wedge every
+        // later refresh
+        exitAttributionRefreshing = false
+        exitAttributionWanted = false
+
         blockActionsSub?.close()
         blockActionsSub = nil
         blockActionStatsSub?.close()
@@ -261,55 +289,116 @@ class BlockActionsStore: ObservableObject {
     }
 
     /**
-     * Runs the exit-attribution re-poll only while a consuming view is
-     * visible; the join is a pull into the extension, so there is no reason
-     * to keep it fresh with nothing rendering it
+     * the consuming view reports its visibility; the join is a pull into the
+     * extension, so there is no reason to keep it fresh with nothing
+     * rendering it
      */
-    func setExitAttributionActive(_ nextActive: Bool) {
-        guard exitAttributionActive != nextActive else {
+    func setExitAttributionActive(_ nextVisible: Bool) {
+        guard exitAttributionVisible != nextVisible else {
             return
         }
-        exitAttributionActive = nextActive
-        if nextActive {
-            refreshExitAttribution()
-            exitAttributionTimer = Timer.scheduledTimer(
-                withTimeInterval: Self.exitAttributionInterval,
-                repeats: true
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.refreshExitAttribution()
-                }
-            }
-        } else {
-            exitAttributionTimer?.invalidate()
-            exitAttributionTimer = nil
+        exitAttributionVisible = nextVisible
+        applyExitAttributionActive()
+    }
+
+    /**
+     * the app stopped presenting the view (backgrounded on iOS; window
+     * hidden, miniaturized or occluded on macOS). A mounted view is not a
+     * presented one -- SwiftUI does not unmount a sheet to background the
+     * app, so without this the poll would keep hitting the extension from
+     * behind a hidden window (android suspends the same job on the process
+     * lifecycle's STOP)
+     */
+    func setExitAttributionSuspended(_ nextSuspended: Bool) {
+        guard exitAttributionSuspended != nextSuspended else {
+            return
         }
+        exitAttributionSuspended = nextSuspended
+        applyExitAttributionActive()
+    }
+
+    private func applyExitAttributionActive() {
+        if exitAttributionActive {
+            refreshExitAttribution()
+            startExitAttributionTimer()
+        } else {
+            stopExitAttributionTimer()
+        }
+    }
+
+    private func startExitAttributionTimer() {
+        guard exitAttributionActive, device != nil, exitAttributionTimer == nil else {
+            return
+        }
+        let timer = Timer(
+            timeInterval: Self.exitAttributionInterval,
+            repeats: true
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.tickExitAttribution()
+            }
+        }
+        // .common: the default mode is suspended while the activity list is
+        // being scrolled, which is exactly when these chips are watched
+        RunLoop.main.add(timer, forMode: .common)
+        exitAttributionTimer = timer
+    }
+
+    private func stopExitAttributionTimer() {
+        exitAttributionTimer?.invalidate()
+        exitAttributionTimer = nil
+    }
+
+    /**
+     * the 5s tick. With no rows on screen there is nothing to attribute, so
+     * the tick costs no rpc (android skips the same way)
+     */
+    private func tickExitAttribution() {
+        guard !blockActions.isEmpty else {
+            return
+        }
+        refreshExitAttribution()
     }
 
     /**
      * Re-pulls the destination->exit join and rebuilds the rows when it
      * moved. The readout is an rpc into the extension, so it runs off the
-     * main thread; refreshes coalesce (at most one in flight)
+     * main thread; at most one is in flight, and a request that arrives
+     * while one is running fires again when it lands
      */
     private func refreshExitAttribution() {
-        guard exitAttributionActive, !exitAttributionRefreshing, let device = self.device else {
+        guard exitAttributionActive, let device = self.device else {
+            return
+        }
+        guard !exitAttributionRefreshing else {
+            exitAttributionWanted = true
             return
         }
         exitAttributionRefreshing = true
+        let generation = self.generation
         Task { [weak self] in
+            // fetchExitsByIp is nonisolated: the synchronous rpc round trip
+            // never runs on the main actor
             let exitsByIp = await Self.fetchExitsByIp(device)
-            guard let self else {
-                return
-            }
-            self.exitAttributionRefreshing = false
-            guard self.device === device else {
-                // the device changed mid-flight; the next refresh reads the new one
-                return
-            }
-            if self.exitsByIp != exitsByIp {
-                self.exitsByIp = exitsByIp
-                self.updateBlockActions()
-            }
+            self?.publishExitAttribution(exitsByIp, generation: generation)
+        }
+    }
+
+    private func publishExitAttribution(_ exitsByIp: [String: Set<String>], generation: Int) {
+        guard generation == self.generation else {
+            // a setup/reset landed while the rpc was in flight; that reset
+            // already cleared the in-flight flag for the new generation
+            return
+        }
+        exitAttributionRefreshing = false
+        if self.exitsByIp != exitsByIp {
+            self.exitsByIp = exitsByIp
+            updateBlockActions()
+        }
+        if exitAttributionWanted {
+            // the trailing edge: the join moved again while this call was out
+            exitAttributionWanted = false
+            refreshExitAttribution()
         }
     }
 

--- a/app/network/Shared/ViewModels/BlockActionsStore.swift
+++ b/app/network/Shared/ViewModels/BlockActionsStore.swift
@@ -35,6 +35,11 @@ struct BlockActionItem: Identifiable, Equatable {
     let hasRouteOverride: Bool
     let packetCount: Int
     let byteCount: Int64
+    // short client ids of the exits CURRENTLY carrying flows to this
+    // cluster's ips (live join against the flow table). One id is the normal
+    // healthy shape; two ids on one row is a site split across egress IPs --
+    // the exact event the affinity work exists to prevent
+    let exitShortIds: [String]
 
     /**
      * every host name (matched + unmatched) and every ip (matched + unmatched)
@@ -63,6 +68,45 @@ struct BlockActionItem: Identifiable, Equatable {
 }
 
 /**
+ * What a site split rule does with the matching cluster's traffic.
+ *
+ * EXCLUDED routes the cluster locally, bypassing the tunnel; INCLUDED routes
+ * it through the tunnel. PINNED is not routing at all: the cluster stays in
+ * the tunnel like any other, but its flows are held to one stable exit, so
+ * the site's api and its cdns present a single egress IP -- the fix for
+ * sites whose images fail to load behind a multi-exit VPN.
+ */
+enum SplitRuleMode {
+    case excluded
+    case included
+    case pinned
+
+    func toSdkRouteOverride() -> SdkRouteOverride? {
+        let route = SdkRouteOverride()
+        switch self {
+        case .excluded:
+            route.local = true
+        case .included:
+            route.local = false
+        case .pinned:
+            route.local = false
+            route.pin = true
+        }
+        return route
+    }
+
+    static func of(local: Bool, pin: Bool) -> SplitRuleMode {
+        if local {
+            return .excluded
+        }
+        if pin {
+            return .pinned
+        }
+        return .included
+    }
+}
+
+/**
  * A block action override ("split rule")
  */
 struct SplitRuleItem: Identifiable, Equatable {
@@ -73,7 +117,7 @@ struct SplitRuleItem: Identifiable, Equatable {
     // exact ip values — both rendered as green chips in the row
     let hostBaseNames: [String]
     let ipValues: [String]
-    let routeLocal: Bool
+    let mode: SplitRuleMode
 }
 
 private class BlockActionsListener: NSObject, SdkBlockActionsListenerProtocol {
@@ -134,6 +178,28 @@ class BlockActionsStore: ObservableObject {
      */
     private var sdkOverrides: [SdkBlockActionOverride] = []
 
+    /**
+     * the live destination->exit attribution, joined onto each cluster's ips
+     * in `updateBlockActions`: destination ip -> short client ids of the
+     * exits CURRENTLY carrying flows to it, after any re-race or rebind
+     */
+    private var exitsByIp: [String: Set<String>] = [:]
+
+    // the exit-attribution re-poll: flows re-race and rebind between
+    // block-action events, so the join is refreshed on a slow tick as well,
+    // active only while a consuming view is visible -- a row growing a
+    // second exit chip mid-session is exactly the observation this feature
+    // exists for
+    private var exitAttributionTimer: Timer?
+    private var exitAttributionActive = false
+    private var exitAttributionRefreshing = false
+
+    private static let exitAttributionInterval: TimeInterval = 5.0
+
+    deinit {
+        exitAttributionTimer?.invalidate()
+    }
+
     func setup(_ device: SdkDeviceRemote) {
         reset()
 
@@ -147,6 +213,9 @@ class BlockActionsStore: ObservableObject {
         self.blockActionsSub = blockActionViewController.add(BlockActionsListener { [weak self] in
             DispatchQueue.main.async {
                 self?.updateBlockActions()
+                // new flows race and bind as routing decisions land, so the
+                // attribution join re-pulls with the burst too
+                self?.refreshExitAttribution()
             }
         })
         self.blockActionStatsSub = blockActionViewController.add(BlockActionStatsListener { [weak self] in
@@ -163,6 +232,7 @@ class BlockActionsStore: ObservableObject {
         updateBlockActions()
         updateBlockStats()
         updateOverrides()
+        refreshExitAttribution()
     }
 
     func reset() {
@@ -187,6 +257,78 @@ class BlockActionsStore: ObservableObject {
         sdkOverrides = []
         allowedCount = 0
         blockedCount = 0
+        exitsByIp = [:]
+    }
+
+    /**
+     * Runs the exit-attribution re-poll only while a consuming view is
+     * visible; the join is a pull into the extension, so there is no reason
+     * to keep it fresh with nothing rendering it
+     */
+    func setExitAttributionActive(_ nextActive: Bool) {
+        guard exitAttributionActive != nextActive else {
+            return
+        }
+        exitAttributionActive = nextActive
+        if nextActive {
+            refreshExitAttribution()
+            exitAttributionTimer = Timer.scheduledTimer(
+                withTimeInterval: Self.exitAttributionInterval,
+                repeats: true
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.refreshExitAttribution()
+                }
+            }
+        } else {
+            exitAttributionTimer?.invalidate()
+            exitAttributionTimer = nil
+        }
+    }
+
+    /**
+     * Re-pulls the destination->exit join and rebuilds the rows when it
+     * moved. The readout is an rpc into the extension, so it runs off the
+     * main thread; refreshes coalesce (at most one in flight)
+     */
+    private func refreshExitAttribution() {
+        guard exitAttributionActive, !exitAttributionRefreshing, let device = self.device else {
+            return
+        }
+        exitAttributionRefreshing = true
+        Task { [weak self] in
+            let exitsByIp = await Self.fetchExitsByIp(device)
+            guard let self else {
+                return
+            }
+            self.exitAttributionRefreshing = false
+            guard self.device === device else {
+                // the device changed mid-flight; the next refresh reads the new one
+                return
+            }
+            if self.exitsByIp != exitsByIp {
+                self.exitsByIp = exitsByIp
+                self.updateBlockActions()
+            }
+        }
+    }
+
+    /**
+     * destination ip -> short client ids of the exits currently carrying
+     * flows to it. nonisolated so the rpc runs off the main actor
+     */
+    private nonisolated static func fetchExitsByIp(_ device: SdkDeviceRemote) async -> [String: Set<String>] {
+        var exitsByIp: [String: Set<String>] = [:]
+        if let destinationExits = device.getDestinationExits() {
+            for i in 0..<destinationExits.len() {
+                guard let destinationExit = destinationExits.get(i),
+                      let idStr = destinationExit.clientId?.idStr else {
+                    continue
+                }
+                exitsByIp[destinationExit.destinationIp, default: []].insert(String(idStr.prefix(8)))
+            }
+        }
+        return exitsByIp
     }
 
     private func updateBlockActions() {
@@ -201,14 +343,24 @@ class BlockActionsStore: ObservableObject {
                     continue
                 }
                 let unmatchedHosts = stringListToArray(action.hosts)
+                let ips = stringListToArray(action.ips)
+                let matchedIps = stringListToArray(action.matchedIps)
+                // the live destination->exit attribution join (see
+                // `refreshExitAttribution`)
+                var exitIds = Set<String>()
+                for ip in matchedIps + ips {
+                    if let exits = exitsByIp[ip] {
+                        exitIds.formUnion(exits)
+                    }
+                }
                 items.append(
                     BlockActionItem(
                         id: action.blockActionId?.idStr ?? UUID().uuidString,
                         time: Date(timeIntervalSince1970: TimeInterval(action.time) / 1000.0),
                         hosts: unmatchedHosts,
-                        ips: stringListToArray(action.ips),
+                        ips: ips,
                         matchedHosts: stringListToArray(action.matchedHosts),
-                        matchedIps: stringListToArray(action.matchedIps),
+                        matchedIps: matchedIps,
                         hostBaseNames: collapseHosts(unmatchedHosts),
                         block: action.block,
                         local: action.local,
@@ -216,7 +368,8 @@ class BlockActionsStore: ObservableObject {
                         hasBlockOverride: action.blockOverride != nil,
                         hasRouteOverride: action.routeOverride != nil,
                         packetCount: action.packetCount,
-                        byteCount: action.byteCount
+                        byteCount: action.byteCount,
+                        exitShortIds: exitIds.sorted()
                     )
                 )
             }
@@ -265,7 +418,12 @@ class BlockActionsStore: ObservableObject {
                         hosts: ruleHosts,
                         hostBaseNames: collapseHosts(ruleHostNames),
                         ipValues: ruleIps,
-                        routeLocal: override.routeOverride?.local ?? false
+                        // excluded when the route override is local, pinned
+                        // when it carries a pin, else included
+                        mode: SplitRuleMode.of(
+                            local: override.routeOverride?.local ?? false,
+                            pin: override.routeOverride?.pin ?? false
+                        )
                     )
                 )
             }
@@ -287,26 +445,25 @@ class BlockActionsStore: ObservableObject {
     }
 
     /**
-     * creates a split rule forcing the selected host values to route local
+     * creates a split rule applying `mode` to the selected host values;
+     * see `SplitRuleMode`
      */
-    func createLocalRule(hosts: [String]) {
+    func createRule(hosts: [String], mode: SplitRuleMode) {
         guard let device = self.device, !hosts.isEmpty else {
             return
         }
         let override = SdkBlockActionOverride()
         override.overrideId = SdkNewId()
         override.hosts = arrayToStringList(hosts)
-        let route = SdkRouteOverride()
-        route.local = true
-        override.routeOverride = route
+        override.routeOverride = mode.toSdkRouteOverride()
         device.add(override)
         updateOverrides()
     }
 
     /**
-     * replaces the host values of an existing split rule
+     * replaces the host values and mode of an existing split rule
      */
-    func updateRule(id: String, hosts: [String]) {
+    func updateRule(id: String, hosts: [String], mode: SplitRuleMode) {
         guard let device = self.device else {
             return
         }
@@ -318,6 +475,7 @@ class BlockActionsStore: ObservableObject {
             return
         }
         override.hosts = arrayToStringList(hosts)
+        override.routeOverride = mode.toSdkRouteOverride()
         let list = SdkBlockActionOverrideList()
         for sdkOverride in sdkOverrides {
             list?.add(sdkOverride)

--- a/app/network/Shared/ViewModels/ReliabilityStore.swift
+++ b/app/network/Shared/ViewModels/ReliabilityStore.swift
@@ -1,0 +1,528 @@
+//
+//  ReliabilityStore.swift
+//  URnetwork
+//
+//  Created by Claude on 8/4/26.
+//
+
+import Foundation
+import SwiftUI
+import URnetworkSdk
+
+/**
+ * Read-only snapshot of the reliability behavior currently in effect on the
+ * extension device: the runtime override when one is set, the shipped
+ * defaults otherwise. Display only -- edits never round-trip through this
+ * snapshot (see `ReliabilityStore.updateSettings`), so a field added on the
+ * sdk side can never be zeroed by an app that does not know about it yet.
+ */
+struct ReliabilitySettings: Equatable {
+    var udpTeardownSignal: Bool = false
+    var quicRebindOnExitLoss: Bool = false
+    var dialFailureRerace: Bool = false
+    var tcpCollapseMaxHoldMillis: Int64 = 0
+    var sendStallTimeoutMillis: Int64 = 0
+    var clusterAffinityFallback: Bool = false
+    var serverNameAffinityBridge: Bool = false
+    var sequenceIdleTimeoutMillis: Int64 = 0
+    var tcpSequenceIdleTimeoutMillis: Int64 = 0
+    var blackholeReceiveTimeoutMillis: Int64 = 0
+    var maxFlowsPerExit: Int32 = 0
+    var affinityStickyPastCap: Bool = false
+    var quarantineGroupFollow: Bool = false
+    var groupFollowWindowMillis: Int64 = 0
+    var uplinkStalenessGateMillis: Int64 = 0
+    var softVerdictDemote: Bool = false
+    var removalBudgetCount: Int32 = 0
+    var removalBudgetWindowMillis: Int64 = 0
+    var standingReserve: Bool = false
+    var effectiveTierSelection: Bool = false
+    var minBlackholeDestinations: Int32 = 0
+    var blackholeLoadCorroboration: Int32 = 0
+    var providerProbe: Bool = false
+    var probeTimeoutMillis: Int64 = 0
+    var probeSampleHostCount: Int32 = 0
+    var probeSilenceWarnStreak: Int32 = 0
+    var evaluationPoolMultiple: Int32 = 0
+    var formationPollTimeoutMillis: Int64 = 0
+    var busyProbe: Bool = false
+    var busyProbeBudgetMillis: Int64 = 0
+    var schedulerPauseToleranceMillis: Int64 = 0
+    var schedulerPauseRecoveryTimeoutMillis: Int64 = 0
+    var blackholeConnectComparativeTimeoutMillis: Int64 = 0
+    var heartbeatIntervalMillis: Int64 = 0
+
+    init() {}
+
+    init(_ settings: SdkReliabilitySettings) {
+        udpTeardownSignal = settings.udpTeardownSignal
+        quicRebindOnExitLoss = settings.quicRebindOnExitLoss
+        dialFailureRerace = settings.dialFailureRerace
+        tcpCollapseMaxHoldMillis = settings.tcpCollapseMaxHoldMillis
+        sendStallTimeoutMillis = settings.sendStallTimeoutMillis
+        clusterAffinityFallback = settings.clusterAffinityFallback
+        serverNameAffinityBridge = settings.serverNameAffinityBridge
+        sequenceIdleTimeoutMillis = settings.sequenceIdleTimeoutMillis
+        tcpSequenceIdleTimeoutMillis = settings.tcpSequenceIdleTimeoutMillis
+        blackholeReceiveTimeoutMillis = settings.blackholeReceiveTimeoutMillis
+        maxFlowsPerExit = settings.maxFlowsPerExit
+        affinityStickyPastCap = settings.affinityStickyPastCap
+        quarantineGroupFollow = settings.quarantineGroupFollow
+        groupFollowWindowMillis = settings.groupFollowWindowMillis
+        uplinkStalenessGateMillis = settings.uplinkStalenessGateMillis
+        softVerdictDemote = settings.softVerdictDemote
+        removalBudgetCount = settings.removalBudgetCount
+        removalBudgetWindowMillis = settings.removalBudgetWindowMillis
+        standingReserve = settings.standingReserve
+        effectiveTierSelection = settings.effectiveTierSelection
+        minBlackholeDestinations = settings.minBlackholeDestinations
+        blackholeLoadCorroboration = settings.blackholeLoadCorroboration
+        providerProbe = settings.providerProbe
+        probeTimeoutMillis = settings.probeTimeoutMillis
+        probeSampleHostCount = settings.probeSampleHostCount
+        probeSilenceWarnStreak = settings.probeSilenceWarnStreak
+        evaluationPoolMultiple = settings.evaluationPoolMultiple
+        formationPollTimeoutMillis = settings.formationPollTimeoutMillis
+        busyProbe = settings.busyProbe
+        busyProbeBudgetMillis = settings.busyProbeBudgetMillis
+        schedulerPauseToleranceMillis = settings.schedulerPauseToleranceMillis
+        schedulerPauseRecoveryTimeoutMillis = settings.schedulerPauseRecoveryTimeoutMillis
+        blackholeConnectComparativeTimeoutMillis = settings.blackholeConnectComparativeTimeoutMillis
+        heartbeatIntervalMillis = settings.heartbeatIntervalMillis
+    }
+}
+
+/**
+ * Counters snapshot: what provider failures have cost since the last reset.
+ * The reliability controls are judged against these -- an A/B run is reset,
+ * set the config, drive the same workload, read the numbers back.
+ */
+struct ReliabilityMetrics: Equatable {
+    var flowsOpened: Int64 = 0
+    var exitLossEvents: Int64 = 0
+    var flowsLostToExit: Int64 = 0
+    var maxFlowsLostInOneEvent: Int64 = 0
+    var meanFlowsLostPerExitLoss: Double = 0
+    var recoveryCount: Int64 = 0
+    var recoveryMissed: Int64 = 0
+    var recoveryMeanMillis: Int64 = 0
+    var recoveryMaxMillis: Int64 = 0
+    var recoveryPending: Int32 = 0
+    var dialFailuresIntercepted: Int64 = 0
+    var flowsReraced: Int64 = 0
+    var flowsRebound: Int64 = 0
+    var rebindsAccepted: Int64 = 0
+    var rebindsRedialed: Int64 = 0
+    var verdictsHeldUplinkStale: Int64 = 0
+    var verdictsHeldTransportDown: Int64 = 0
+    var removalsDeferred: Int64 = 0
+    var probesSent: Int64 = 0
+    var probesAnswered: Int64 = 0
+    var providersQualified: Int64 = 0
+    var busyProbesSent: Int64 = 0
+    var busyProbesAcquitted: Int64 = 0
+    var schedulerPausesDetected: Int64 = 0
+    var groupsFollowed: Int64 = 0
+    var groupsScattered: Int64 = 0
+
+    init() {}
+
+    init(_ metrics: SdkReliabilityMetrics) {
+        flowsOpened = metrics.flowsOpened
+        exitLossEvents = metrics.exitLossEvents
+        flowsLostToExit = metrics.flowsLostToExit
+        maxFlowsLostInOneEvent = metrics.maxFlowsLostInOneEvent
+        meanFlowsLostPerExitLoss = metrics.meanFlowsLostPerExitLoss
+        recoveryCount = metrics.recoveryCount
+        recoveryMissed = metrics.recoveryMissed
+        recoveryMeanMillis = metrics.recoveryMeanMillis
+        recoveryMaxMillis = metrics.recoveryMaxMillis
+        recoveryPending = metrics.recoveryPending
+        dialFailuresIntercepted = metrics.dialFailuresIntercepted
+        flowsReraced = metrics.flowsReraced
+        flowsRebound = metrics.flowsRebound
+        rebindsAccepted = metrics.rebindsAccepted
+        rebindsRedialed = metrics.rebindsRedialed
+        verdictsHeldUplinkStale = metrics.verdictsHeldUplinkStale
+        verdictsHeldTransportDown = metrics.verdictsHeldTransportDown
+        removalsDeferred = metrics.removalsDeferred
+        probesSent = metrics.probesSent
+        probesAnswered = metrics.probesAnswered
+        providersQualified = metrics.providersQualified
+        busyProbesSent = metrics.busyProbesSent
+        busyProbesAcquitted = metrics.busyProbesAcquitted
+        schedulerPausesDetected = metrics.schedulerPausesDetected
+        groupsFollowed = metrics.groupsFollowed
+        groupsScattered = metrics.groupsScattered
+    }
+}
+
+/**
+ * One provider channel, as shown in the developer screen exit readout.
+ */
+struct ReliabilityExit: Identifiable, Equatable {
+    let id: String
+    // "quality", "speed", or "" for auto
+    let windowType: String
+    let warning: Bool
+    let quarantined: Bool
+    // WHY the exit is warned, named by the go side. Rendered verbatim so
+    // causes added later ("silent", ...) display without an app update
+    let warningCause: String
+    let done: Bool
+    let p2pOnly: Bool
+    let flowCount: Int32
+    let dialFailureCount: Int32
+    let tier: Int32
+    let effectiveTier: Int32
+    let proven: Bool
+    // seconds since last proven; -1 is never
+    let probeAgeSeconds: Int64
+
+    init(_ exit: SdkExit) {
+        id = exit.clientId?.idStr ?? UUID().uuidString
+        windowType = exit.windowType
+        warning = exit.warning
+        quarantined = exit.quarantined
+        warningCause = exit.warningCause
+        done = exit.done
+        p2pOnly = exit.p2pOnly
+        flowCount = exit.flowCount
+        dialFailureCount = exit.dialFailureCount
+        tier = exit.tier
+        effectiveTier = exit.effectiveTier
+        proven = exit.proven
+        probeAgeSeconds = exit.probeAgeSeconds
+    }
+
+    /**
+     * A short label that actually distinguishes one exit from another. Client
+     * ids are ULIDs: the leading characters encode creation time, and the
+     * channels in a window are opened within milliseconds of each other, so a
+     * leading substring renders every row identical. The entropy is in the
+     * tail.
+     */
+    var label: String {
+        String(id.suffix(8))
+    }
+
+    /**
+     * The one-line state summary: window type, tier (with the effective-tier
+     * demotion when selection has demoted the exit), the warning state by
+     * name, and the lifecycle chips. The warning cause string passes through
+     * verbatim -- new causes must display without an app update.
+     */
+    var stateLine: String {
+        var parts: [String] = [windowType.isEmpty ? "auto" : windowType]
+
+        // the platform's rank for this provider. only the best rank present is
+        // raced until it is at the flow cap, so a tier above the minimum with
+        // 0 flows is a spare, not a failure. effectiveTier is the rank
+        // selection actually uses (tier plus live demerits); when it differs
+        // the exit is demoted and "tier N→M" makes that visible
+        var tierPart = "tier \(tier)"
+        if tier < effectiveTier {
+            tierPart += "→\(effectiveTier)"
+        }
+        parts.append(tierPart)
+
+        // "benched" is a quarantine (a soft verdict held against a loaded
+        // exit -- it stops taking new placements while its flows keep running,
+        // and receive progress acquits it); otherwise the resize pass's cause
+        // string, verbatim
+        if quarantined {
+            parts.append("benched")
+        } else if warning {
+            parts.append(warningCause.isEmpty ? "warned" : warningCause)
+        }
+        if done {
+            parts.append("done")
+        }
+        if p2pOnly {
+            parts.append("p2p")
+        }
+        // a probe pass (or the exit's own traffic) proved this provider dials
+        // real destinations within the qualification window. Absence of the
+        // chip is "not yet proven", never "bad"
+        if proven {
+            parts.append("proven")
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+private func mapExits(_ list: SdkExitList?) -> [ReliabilityExit] {
+    guard let list = list else {
+        return []
+    }
+    var exits: [ReliabilityExit] = []
+    exits.reserveCapacity(list.len())
+    for i in 0..<list.len() {
+        if let exit = list.get(i) {
+            exits.append(ReliabilityExit(exit))
+        }
+    }
+    return exits
+}
+
+/**
+ * Publishes the live reliability surface for the developer screen: the
+ * effective settings, the counters, and the per-exit readout.
+ *
+ * Every DeviceRemote call here is a synchronous rpc round trip to the packet
+ * tunnel extension, so they all run off the main actor. The screen's 5s poll
+ * runs only while the screen is visible (`setActive`) and a device is set;
+ * everything tolerates `device == nil` (tunnel down) and a replaced device
+ * object (extension restart) mid-flight.
+ */
+@MainActor
+class ReliabilityStore: ObservableObject {
+
+    /**
+     * how often the developer screen re-reads the reliability surface while
+     * open. The counters move on their own -- a stalled exit takes seconds to
+     * be detected -- and without polling a stale zero reads as "no provider
+     * failures" rather than "nothing measured yet"
+     */
+    static let pollInterval: TimeInterval = 5
+
+    @Published private(set) var settings: ReliabilitySettings? = nil
+    @Published private(set) var metrics: ReliabilityMetrics? = nil
+    @Published private(set) var exits: [ReliabilityExit] = []
+    @Published private(set) var lastAction: String? = nil
+
+    /**
+     * nil settings while disconnected -- there is no multi client to read
+     * from, so the controls have nothing to act on and the screen shows a
+     * connect hint rather than reporting defaults that are not in force
+     */
+    var connected: Bool {
+        settings != nil
+    }
+
+    private var device: SdkDeviceRemote?
+
+    // true while the developer screen is visible
+    private var active = false
+    private var pollTimer: Timer?
+
+    // bumped on every setup/reset so a refresh that started against an old
+    // device (or before a reset) can never publish over newer state
+    private var generation = 0
+
+    deinit {
+        pollTimer?.invalidate()
+    }
+
+    func setup(_ device: SdkDeviceRemote) {
+        reset()
+
+        self.device = device
+        refresh()
+        if active {
+            startPolling()
+        }
+    }
+
+    func reset() {
+        generation += 1
+        stopPolling()
+        device = nil
+
+        settings = nil
+        metrics = nil
+        exits = []
+        lastAction = nil
+    }
+
+    /**
+     * the developer screen reports its visibility; the poll runs only while
+     * visible and is cancelled the moment the screen goes away
+     */
+    func setActive(_ nextActive: Bool) {
+        guard active != nextActive else {
+            return
+        }
+        active = nextActive
+        if active {
+            refresh()
+            startPolling()
+        } else {
+            stopPolling()
+        }
+    }
+
+    private func startPolling() {
+        guard active, device != nil, pollTimer == nil else {
+            return
+        }
+        pollTimer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refresh()
+            }
+        }
+    }
+
+    private func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    func refresh() {
+        guard let device = self.device else {
+            return
+        }
+        let generation = self.generation
+        Task.detached(priority: .userInitiated) { [weak self] in
+            // each getter is a synchronous rpc round trip; never on the main actor
+            let settings = device.getReliabilitySettings().map { ReliabilitySettings($0) }
+            let metrics = device.getReliabilityMetrics().map { ReliabilityMetrics($0) }
+            let exits = mapExits(device.getExits())
+            await self?.publish(
+                settings: settings,
+                metrics: metrics,
+                exits: exits,
+                generation: generation
+            )
+        }
+    }
+
+    private func publish(
+        settings: ReliabilitySettings?,
+        metrics: ReliabilityMetrics?,
+        exits: [ReliabilityExit],
+        generation: Int
+    ) {
+        guard generation == self.generation else {
+            return
+        }
+        if settings != self.settings {
+            self.settings = settings
+        }
+        if metrics != self.metrics {
+            self.metrics = metrics
+        }
+        if exits != self.exits {
+            self.exits = exits
+        }
+    }
+
+    /**
+     * Applies one settings change as a read-modify-write of the FULL settings
+     * struct against a FRESH read from the device. Deliberately never writes
+     * back a cached snapshot: a stale one (read while the tunnel was down, or
+     * before another writer's change) is partly or wholly zero-valued, and
+     * `setReliabilitySettings` applies the whole struct -- writing it back
+     * would silently turn every other reliability fix off.
+     */
+    func updateSettings(_ mutate: @escaping (SdkReliabilitySettings) -> Void) {
+        guard let device = self.device else {
+            return
+        }
+        let generation = self.generation
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let sdkSettings = device.getReliabilitySettings() else {
+                return
+            }
+            mutate(sdkSettings)
+            device.setReliabilitySettings(sdkSettings)
+            // read back the now-effective values so the ui reflects what the
+            // device actually applied, not what was asked for
+            let settings = device.getReliabilitySettings().map { ReliabilitySettings($0) }
+            await self?.publishSettings(settings, generation: generation)
+        }
+    }
+
+    private func publishSettings(_ settings: ReliabilitySettings?, generation: Int) {
+        guard generation == self.generation else {
+            return
+        }
+        if settings != self.settings {
+            self.settings = settings
+        }
+    }
+
+    /**
+     * Clears the runtime override, restoring the shipped behavior -- the "put
+     * it back" that makes every experiment undoable.
+     */
+    func resetSettings() {
+        performAction("Reset to shipped defaults") { device in
+            _ = device.resetReliabilitySettings()
+        }
+    }
+
+    /**
+     * Zeroes the counters so a run starts clean. The A/B cycle is: reset, set
+     * the config, drive the same workload, read the numbers back.
+     */
+    func resetMetrics() {
+        performAction("Reset measurements") { device in
+            _ = device.resetReliabilityMetrics()
+        }
+    }
+
+    /**
+     * Hands one exit's movable (established QUIC) flows to live replacements
+     * now, while the exit stays alive -- the drain-style hand-off on demand.
+     * Nothing is killed: TCP and anything unplaceable keeps working where it
+     * is.
+     */
+    func migrateExit(_ exit: ReliabilityExit) {
+        performAction("Migrated exit \(exit.label)") { device in
+            _ = device.migrateExit(exit.id)
+        }
+    }
+
+    /**
+     * Fires one qualification probe pass at this exit right now instead of
+     * waiting for the background sweep.
+     */
+    func probeExit(_ exit: ReliabilityExit) {
+        performAction("Probing exit \(exit.label)") { device in
+            _ = device.probeExit(exit.id)
+        }
+    }
+
+    /**
+     * Fires a qualification probe pass at every exit right now. Non-blocking;
+     * the Probes counter moves as the passes complete. No-op while provider
+     * probing is off.
+     */
+    func probeAllExits() {
+        performAction("Probing all exits") { device in
+            _ = device.probeAllExits()
+        }
+    }
+
+    /**
+     * Fires the platform network-change path on demand -- the uplink epoch
+     * reset and the transport kick a real wifi-to-cellular migration triggers
+     * -- so the storm drill the uplink gate exists for is one tap instead of
+     * physically moving between networks.
+     */
+    func simulateNetworkChange() {
+        performAction("Simulated network change") { device in
+            _ = device.simulateNetworkChange()
+        }
+    }
+
+    private func performAction(_ description: String, _ action: @escaping (SdkDeviceRemote) -> Void) {
+        guard let device = self.device else {
+            return
+        }
+        let generation = self.generation
+        Task.detached(priority: .userInitiated) { [weak self] in
+            action(device)
+            await self?.finishAction(description, generation: generation)
+        }
+    }
+
+    private func finishAction(_ description: String, generation: Int) {
+        guard generation == self.generation else {
+            return
+        }
+        lastAction = description
+        refresh()
+    }
+}

--- a/app/network/Shared/ViewModels/ReliabilityStore.swift
+++ b/app/network/Shared/ViewModels/ReliabilityStore.swift
@@ -179,8 +179,18 @@ struct ReliabilityExit: Identifiable, Equatable {
     // seconds since last proven; -1 is never
     let probeAgeSeconds: Int64
 
-    init(_ exit: SdkExit) {
-        id = exit.clientId?.idStr ?? UUID().uuidString
+    /**
+     * nil for an exit with no client id. The go side always populates one, so
+     * this is latent -- but an exit without an id is not addressable (migrate
+     * parses it back into an Id) and substituting a fresh uuid would mint a
+     * new ForEach identity on every 5s poll, rebuilding the row and sending
+     * garbage to the bridge.
+     */
+    init?(_ exit: SdkExit) {
+        guard let clientId = exit.clientId?.idStr, !clientId.isEmpty else {
+            return nil
+        }
+        id = clientId
         windowType = exit.windowType
         warning = exit.warning
         quarantined = exit.quarantined
@@ -258,8 +268,8 @@ private func mapExits(_ list: SdkExitList?) -> [ReliabilityExit] {
     var exits: [ReliabilityExit] = []
     exits.reserveCapacity(list.len())
     for i in 0..<list.len() {
-        if let exit = list.get(i) {
-            exits.append(ReliabilityExit(exit))
+        if let exit = list.get(i), let row = ReliabilityExit(exit) {
+            exits.append(row)
         }
     }
     return exits
@@ -270,10 +280,16 @@ private func mapExits(_ list: SdkExitList?) -> [ReliabilityExit] {
  * effective settings, the counters, and the per-exit readout.
  *
  * Every DeviceRemote call here is a synchronous rpc round trip to the packet
- * tunnel extension, so they all run off the main actor. The screen's 5s poll
- * runs only while the screen is visible (`setActive`) and a device is set;
- * everything tolerates `device == nil` (tunnel down) and a replaced device
- * object (extension restart) mid-flight.
+ * tunnel extension, so they all run off the main actor, serialized on one
+ * queue (see `bridgeQueue`). The screen's 5s poll runs only while the screen
+ * is visible (`setActive`) and a device is set; everything tolerates
+ * `device == nil` (tunnel down) and a replaced device object (extension
+ * restart) mid-flight.
+ *
+ * `settings` is nil whenever the extension has no multi client to override --
+ * which on iOS is NOT the same as "no device": the DeviceRemote is created at
+ * login and outlives every tunnel session, so a non-nil device says nothing
+ * about whether there is anything to configure.
  */
 @MainActor
 class ReliabilityStore: ObservableObject {
@@ -292,15 +308,28 @@ class ReliabilityStore: ObservableObject {
     @Published private(set) var lastAction: String? = nil
 
     /**
-     * nil settings while disconnected -- there is no multi client to read
-     * from, so the controls have nothing to act on and the screen shows a
-     * connect hint rather than reporting defaults that are not in force
+     * nil settings means there is no multi client behind the bridge -- the
+     * tunnel is down, so the controls have nothing to act on and the screen
+     * shows a connect hint rather than reporting defaults that are not in
+     * force. This is the ONLY honest connected signal on iOS: the device
+     * itself is created at login and exists whether or not the tunnel is up.
      */
     var connected: Bool {
         settings != nil
     }
 
     private var device: SdkDeviceRemote?
+
+    /**
+     * Every DeviceRemote call runs here: off the main thread, and serialized.
+     *
+     * Serialization is load-bearing, not hygiene. A settings mutation is a
+     * read-modify-write of the FULL struct, so two overlapping mutations lose
+     * a field -- the second reads before the first has written, then reverts
+     * it with its own full-struct write. Reads share the queue too, so a poll
+     * can never publish a snapshot it read halfway through a write.
+     */
+    private let bridgeQueue = DispatchQueue(label: "com.urnetwork.ReliabilityStore.bridge")
 
     // true while the developer screen is visible
     private var active = false
@@ -356,11 +385,15 @@ class ReliabilityStore: ObservableObject {
         guard active, device != nil, pollTimer == nil else {
             return
         }
-        pollTimer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.refresh()
             }
         }
+        // .common: the default mode is suspended while the form is being
+        // scrolled, which is exactly when the counters are being watched
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
     }
 
     private func stopPolling() {
@@ -373,17 +406,22 @@ class ReliabilityStore: ObservableObject {
             return
         }
         let generation = self.generation
-        Task.detached(priority: .userInitiated) { [weak self] in
-            // each getter is a synchronous rpc round trip; never on the main actor
+        bridgeQueue.async { [weak self] in
+            // each getter is a synchronous rpc round trip; never on the main
+            // actor, and never overlapping a write on this queue.
+            // settings is nil with no multi client behind the bridge; metrics
+            // and the exit list honestly degrade to zeros and empty
             let settings = device.getReliabilitySettings().map { ReliabilitySettings($0) }
             let metrics = device.getReliabilityMetrics().map { ReliabilityMetrics($0) }
             let exits = mapExits(device.getExits())
-            await self?.publish(
-                settings: settings,
-                metrics: metrics,
-                exits: exits,
-                generation: generation
-            )
+            Task { @MainActor [weak self] in
+                self?.publish(
+                    settings: settings,
+                    metrics: metrics,
+                    exits: exits,
+                    generation: generation
+                )
+            }
         }
     }
 
@@ -409,19 +447,30 @@ class ReliabilityStore: ObservableObject {
 
     /**
      * Applies one settings change as a read-modify-write of the FULL settings
-     * struct against a FRESH read from the device. Deliberately never writes
-     * back a cached snapshot: a stale one (read while the tunnel was down, or
-     * before another writer's change) is partly or wholly zero-valued, and
-     * `setReliabilitySettings` applies the whole struct -- writing it back
-     * would silently turn every other reliability fix off.
+     * struct against a FRESH read from the device, serialized against every
+     * other bridge call.
+     *
+     * Two traps meet here. Writing back a CACHED snapshot would apply a
+     * partly-or-wholly zero-valued struct (`setReliabilitySettings` takes the
+     * whole thing), silently turning every other reliability fix off. And a
+     * fresh read of NIL means there is no multi client to override at all --
+     * writing then would install an all-zero override that the bridge's sync
+     * state re-applies when the extension starts, disabling the entire
+     * reliability stack for the session. Neither is hypothetical on iOS,
+     * where the device exists from login onward regardless of the tunnel.
      */
     func updateSettings(_ mutate: @escaping (SdkReliabilitySettings) -> Void) {
         guard let device = self.device else {
             return
         }
         let generation = self.generation
-        Task.detached(priority: .userInitiated) { [weak self] in
+        bridgeQueue.async { [weak self] in
             guard let sdkSettings = device.getReliabilitySettings() else {
+                // nothing to override; publish the nil so the screen falls
+                // back to the connect hint instead of showing dead controls
+                Task { @MainActor [weak self] in
+                    self?.publishSettings(nil, generation: generation)
+                }
                 return
             }
             mutate(sdkSettings)
@@ -429,7 +478,9 @@ class ReliabilityStore: ObservableObject {
             // read back the now-effective values so the ui reflects what the
             // device actually applied, not what was asked for
             let settings = device.getReliabilitySettings().map { ReliabilitySettings($0) }
-            await self?.publishSettings(settings, generation: generation)
+            Task { @MainActor [weak self] in
+                self?.publishSettings(settings, generation: generation)
+            }
         }
     }
 
@@ -447,7 +498,7 @@ class ReliabilityStore: ObservableObject {
      * it back" that makes every experiment undoable.
      */
     func resetSettings() {
-        performAction("Reset to shipped defaults") { device in
+        performAction("reset to shipped defaults") { device in
             _ = device.resetReliabilitySettings()
         }
     }
@@ -457,7 +508,7 @@ class ReliabilityStore: ObservableObject {
      * the config, drive the same workload, read the numbers back.
      */
     func resetMetrics() {
-        performAction("Reset measurements") { device in
+        performAction("reset measurements") { device in
             _ = device.resetReliabilityMetrics()
         }
     }
@@ -469,7 +520,7 @@ class ReliabilityStore: ObservableObject {
      * is.
      */
     func migrateExit(_ exit: ReliabilityExit) {
-        performAction("Migrated exit \(exit.label)") { device in
+        performAction("migrate exit \(exit.label)") { device in
             _ = device.migrateExit(exit.id)
         }
     }
@@ -484,7 +535,7 @@ class ReliabilityStore: ObservableObject {
      * probing is off.
      */
     func probeAllExits() {
-        performAction("Probing all exits") { device in
+        performAction("probe all exits") { device in
             _ = device.probeAllExits()
         }
     }
@@ -496,19 +547,31 @@ class ReliabilityStore: ObservableObject {
      * physically moving between networks.
      */
     func simulateNetworkChange() {
-        performAction("Simulated network change") { device in
+        performAction("simulate network change") { device in
             _ = device.simulateNetworkChange()
         }
     }
 
+    /**
+     * Runs one action on the bridge queue and records it.
+     *
+     * `description` names what was ASKED FOR, never what happened: every
+     * action on the frozen contract returns void, and each one is a silent
+     * no-op when there is no multi client behind the rpc. Reporting
+     * "Simulated network change" when nothing happened is exactly the
+     * mechanism-with-no-field-observable-signal failure this screen exists to
+     * catch. The counters and exit rows refreshed underneath are the evidence.
+     */
     private func performAction(_ description: String, _ action: @escaping (SdkDeviceRemote) -> Void) {
         guard let device = self.device else {
             return
         }
         let generation = self.generation
-        Task.detached(priority: .userInitiated) { [weak self] in
+        bridgeQueue.async { [weak self] in
             action(device)
-            await self?.finishAction(description, generation: generation)
+            Task { @MainActor [weak self] in
+                self?.finishAction(description, generation: generation)
+            }
         }
     }
 
@@ -516,7 +579,7 @@ class ReliabilityStore: ObservableObject {
         guard generation == self.generation else {
             return
         }
-        lastAction = description
+        lastAction = "Requested: \(description)"
         refresh()
     }
 }

--- a/app/network/Shared/ViewModels/ReliabilityStore.swift
+++ b/app/network/Shared/ViewModels/ReliabilityStore.swift
@@ -474,15 +474,9 @@ class ReliabilityStore: ObservableObject {
         }
     }
 
-    /**
-     * Fires one qualification probe pass at this exit right now instead of
-     * waiting for the background sweep.
-     */
-    func probeExit(_ exit: ReliabilityExit) {
-        performAction("Probing exit \(exit.label)") { device in
-            _ = device.probeExit(exit.id)
-        }
-    }
+    // There is no per-exit probe: connect exposes only a full sweep
+    // (ProbeAllExits), and the android developer screen has no per-row probe
+    // either, so the sweep below is the whole probing surface.
 
     /**
      * Fires a qualification probe pass at every exit right now. Non-blocking;

--- a/app/network/Shared/Views/Stats/SplitRulesView.swift
+++ b/app/network/Shared/Views/Stats/SplitRulesView.swift
@@ -25,6 +25,7 @@ struct SplitRulesView: View {
         let candidates: [String]
         let selected: Set<String>
         let ruleId: String?
+        let mode: SplitRuleMode
     }
 
     @State private var editorTarget: EditorTarget? = nil
@@ -111,7 +112,8 @@ struct SplitRulesView: View {
                                     id: rule.id,
                                     candidates: rule.hosts,
                                     selected: Set(rule.hosts),
-                                    ruleId: rule.id
+                                    ruleId: rule.id,
+                                    mode: rule.mode
                                 )
                             }
                             .contextMenu {
@@ -214,6 +216,10 @@ struct SplitRulesView: View {
         .background(themeManager.currentTheme.backgroundColor)
         .onAppear {
             displayedActions = blockActionsStore.blockActions
+            blockActionsStore.setExitAttributionActive(true)
+        }
+        .onDisappear {
+            blockActionsStore.setExitAttributionActive(false)
         }
         .onChange(of: blockActionsStore.blockActions) { blockActions in
             if isAtTop {
@@ -224,7 +230,8 @@ struct SplitRulesView: View {
             SplitRuleEditorView(
                 candidates: target.candidates,
                 initialSelection: target.selected,
-                ruleId: target.ruleId
+                ruleId: target.ruleId,
+                initialMode: target.mode
             )
             .environmentObject(themeManager)
             .environmentObject(blockActionsStore)
@@ -265,7 +272,8 @@ struct SplitRulesView: View {
                 id: action.id,
                 candidates: candidates,
                 selected: Set(rule.hosts),
-                ruleId: rule.id
+                ruleId: rule.id,
+                mode: rule.mode
             )
         } else {
             // create a rule from the action's host values, all initially UNSELECTED:
@@ -275,7 +283,8 @@ struct SplitRulesView: View {
                 id: action.id,
                 candidates: action.hostValues,
                 selected: [],
-                ruleId: nil
+                ruleId: nil,
+                mode: .excluded
             )
         }
     }
@@ -307,7 +316,7 @@ private struct SplitRulesTopOffsetKey: PreferenceKey {
 }
 
 // A split rule (override) row: all of the rule's host base names and exact ips as
-// green chips (the whole rule is "active"), with the Local state chip trailing.
+// green chips (the whole rule is "active"), with the mode state chip trailing.
 struct SplitRuleRowView: View {
 
     @EnvironmentObject var themeManager: ThemeManager
@@ -327,7 +336,17 @@ struct SplitRuleRowView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            StateChip(text: "Local", color: .urGreen, highlighted: true)
+            // an excluded cluster routes locally: the same Local language as
+            // the activity rows. a pinned cluster is in the tunnel like any
+            // other, just held to one exit
+            switch rule.mode {
+            case .excluded:
+                StateChip(text: "Local", color: .urGreen, highlighted: true)
+            case .pinned:
+                StateChip(text: "Pinned", color: .urElectricBlue, highlighted: true)
+            case .included:
+                StateChip(text: "Included", color: .urElectricBlue, highlighted: true)
+            }
 
         }
         .padding(.vertical, 4)
@@ -370,6 +389,15 @@ struct BlockActionRowView: View {
                     Text(relativeTime(action.time))
                     if 0 < action.byteCount {
                         Text(formatByteCountCompact(action.byteCount))
+                    }
+                    // which exit(s) carry this cluster right now. One chip is
+                    // the healthy shape; two chips on one row is the site
+                    // split across egress IPs, live
+                    ForEach(action.exitShortIds, id: \.self) { exitId in
+                        ExitChip(
+                            exitShortId: exitId,
+                            split: 1 < action.exitShortIds.count
+                        )
                     }
                 }
                 .font(.system(size: 11).monospacedDigit())
@@ -466,6 +494,29 @@ struct IPsPill: View {
     }
 }
 
+// The exit currently carrying a cluster's flows, as a tinted "via <short client
+// id>" capsule. One chip on a row is the normal healthy shape; when a row splits
+// across exits, every chip flips to coral so the split-egress observation --
+// the exact event the site affinity work exists to prevent -- is unmissable.
+struct ExitChip: View {
+
+    @EnvironmentObject var themeManager: ThemeManager
+
+    let exitShortId: String
+    let split: Bool
+
+    var body: some View {
+        let color = split ? Color.urCoral : themeManager.currentTheme.accentColor
+        Text("via \(exitShortId)")
+            .font(.system(size: 10, weight: .medium).monospaced())
+            .foregroundColor(color)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.14))
+            .clipShape(Capsule())
+    }
+}
+
 // A flow layout that places chips left-to-right and wraps to a new line when the
 // next chip would overflow the available width.
 struct ChipFlowLayout: Layout {
@@ -534,7 +585,9 @@ struct StateChip: View {
 }
 
 /**
- * Create or edit a split rule: select the host values to route locally
+ * Create or edit a split rule: select the host values and what the rule does
+ * with them -- route locally (excluded), pin to one provider, or route
+ * through the tunnel (included); see `SplitRuleMode`
  */
 struct SplitRuleEditorView: View {
 
@@ -546,11 +599,13 @@ struct SplitRuleEditorView: View {
     let ruleId: String?
 
     @State private var selection: Set<String>
+    @State private var mode: SplitRuleMode
 
-    init(candidates: [String], initialSelection: Set<String>, ruleId: String?) {
+    init(candidates: [String], initialSelection: Set<String>, ruleId: String?, initialMode: SplitRuleMode) {
         self.candidates = candidates
         self.ruleId = ruleId
         _selection = State(initialValue: initialSelection)
+        _mode = State(initialValue: initialMode)
     }
 
     private var isEditing: Bool {
@@ -576,10 +631,27 @@ struct SplitRuleEditorView: View {
             }
             .padding()
 
-            Text("Selected hosts are routed locally and bypass the tunnel.")
-                .font(themeManager.currentTheme.secondaryBodyFont)
-                .foregroundColor(themeManager.currentTheme.textMutedColor)
-                .padding(.horizontal)
+            // what the rule does with the selected hosts, one exclusive choice
+            VStack(spacing: 0) {
+                modeRow(
+                    .excluded,
+                    title: "Route locally",
+                    description: "Selected hosts bypass the tunnel."
+                )
+                // pin: the cluster stays in the tunnel, but its traffic is
+                // held to one exit so the site's api and cdns share an egress ip
+                modeRow(
+                    .pinned,
+                    title: "Pin to one provider",
+                    description: "Keeps the selected hosts on a single provider, so the site's API and images share one IP address. Use for sites whose content fails to load through the VPN."
+                )
+                modeRow(
+                    .included,
+                    title: "Route through VPN",
+                    description: "Selected hosts are routed through the tunnel."
+                )
+            }
+            .padding(.horizontal)
 
             List {
                 ForEach(candidates, id: \.self) { host in
@@ -618,9 +690,9 @@ struct SplitRuleEditorView: View {
                     action: {
                         let hosts = candidates.filter { selection.contains($0) }
                         if let ruleId = ruleId {
-                            blockActionsStore.updateRule(id: ruleId, hosts: hosts)
+                            blockActionsStore.updateRule(id: ruleId, hosts: hosts, mode: mode)
                         } else {
-                            blockActionsStore.createLocalRule(hosts: hosts)
+                            blockActionsStore.createRule(hosts: hosts, mode: mode)
                         }
                         dismiss()
                     },
@@ -644,5 +716,44 @@ struct SplitRuleEditorView: View {
 
         }
         .background(themeManager.currentTheme.backgroundColor)
+    }
+
+    /**
+     * one exclusive mode choice: a radio-style circle with the mode title
+     * and what it does
+     */
+    private func modeRow(
+        _ rowMode: SplitRuleMode,
+        title: LocalizedStringKey,
+        description: LocalizedStringKey
+    ) -> some View {
+        let selected = mode == rowMode
+        return HStack(alignment: .top, spacing: 10) {
+
+            Image(systemName: selected ? "circle.inset.filled" : "circle")
+                .foregroundColor(
+                    selected
+                        ? .urGreen
+                        : themeManager.currentTheme.textFaintColor
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(themeManager.currentTheme.bodyFont)
+                    .foregroundColor(themeManager.currentTheme.textColor)
+                Text(description)
+                    .font(themeManager.currentTheme.secondaryBodyFont)
+                    .foregroundColor(themeManager.currentTheme.textMutedColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+
+        }
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            mode = rowMode
+        }
     }
 }

--- a/app/network/Shared/Views/Stats/SplitRulesView.swift
+++ b/app/network/Shared/Views/Stats/SplitRulesView.swift
@@ -19,6 +19,7 @@ struct SplitRulesView: View {
 
     @EnvironmentObject var themeManager: ThemeManager
     @EnvironmentObject var blockActionsStore: BlockActionsStore
+    @Environment(\.presentationActive) private var presentationActive
 
     private struct EditorTarget: Identifiable {
         let id: String
@@ -76,9 +77,9 @@ struct SplitRulesView: View {
                 )
 
             /**
-             * Info: how exclusions work
+             * Info: how rules apply
              */
-            Text("Exclusions apply to the whole co-associated network cluster, so related traffic is caught together.")
+            Text("Rules apply to the whole co-associated network cluster, so related traffic is caught together.")
                 .font(themeManager.currentTheme.secondaryBodyFont)
                 .foregroundColor(themeManager.currentTheme.textMutedColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -99,7 +100,7 @@ struct SplitRulesView: View {
             ) {
 
                 if blockActionsStore.splitRules.isEmpty {
-                    Text("Tap traffic below to route it locally, bypassing the tunnel.")
+                    Text("Tap traffic below to route it locally or hold it to one provider.")
                         .font(themeManager.currentTheme.secondaryBodyFont)
                         .foregroundColor(themeManager.currentTheme.textFaintColor)
                         .listRowBackground(Color.clear)
@@ -216,14 +217,33 @@ struct SplitRulesView: View {
         .background(themeManager.currentTheme.backgroundColor)
         .onAppear {
             displayedActions = blockActionsStore.blockActions
+            // a sheet is only ever mounted while the app is presenting it, so
+            // "not suspended" is the right starting state; the transitions
+            // below carry it from there
             blockActionsStore.setExitAttributionActive(true)
+        }
+        .onChange(of: presentationActive) { active in
+            blockActionsStore.setExitAttributionSuspended(!active)
         }
         .onDisappear {
             blockActionsStore.setExitAttributionActive(false)
+            blockActionsStore.setExitAttributionSuspended(false)
         }
         .onChange(of: blockActionsStore.blockActions) { blockActions in
             if isAtTop {
                 displayedActions = blockActions
+            } else {
+                // the frozen list still tracks attribution (and byte counts)
+                // for the rows already on screen: an attribution-only rebuild
+                // reuses the row ids, so it would otherwise never reach the
+                // reader -- no "N new" chip counts it, and watching a row grow
+                // a second exit chip is the whole point. Membership and order
+                // stay frozen, so nothing shifts under the reader.
+                let liveById = Dictionary(
+                    blockActions.map { ($0.id, $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                displayedActions = displayedActions.map { liveById[$0.id] ?? $0 }
             }
         }
         .sheet(item: $editorTarget) { target in
@@ -638,17 +658,18 @@ struct SplitRuleEditorView: View {
                     title: "Route locally",
                     description: "Selected hosts bypass the tunnel."
                 )
-                // pin: the cluster stays in the tunnel, but its traffic is
-                // held to one exit so the site's api and cdns share an egress ip
+                // a site pin is exit STABILITY, not consolidation: the hosts
+                // keep their ordinary grouping and simply hold a benched exit
+                // longer before being re-raced off it (see SplitRuleMode)
                 modeRow(
                     .pinned,
-                    title: "Pin to one provider",
-                    description: "Keeps the selected hosts on a single provider, so the site's API and images share one IP address. Use for sites whose content fails to load through the VPN."
+                    title: "Keep on one provider",
+                    description: "Selected hosts hold their provider longer instead of being moved at the first sign of trouble, so the site changes IP addresses less often mid-session."
                 )
                 modeRow(
                     .included,
                     title: "Route through VPN",
-                    description: "Selected hosts are routed through the tunnel."
+                    description: "The default: selected hosts use the tunnel with no pin."
                 )
             }
             .padding(.horizontal)


### PR DESCRIPTION
Brings the reliability work that landed for Android (connect#190, sdk#134, android#468) to iOS and macOS. connect and sdk are shared, so the reliability stack itself — the flows-are-sacred verdict layer, the provider prober, site affinity, the `[rel]` observability — is already running in the extension the moment the xcframework is rebuilt. What was missing was the UI, and the RPC bridge to reach it.

**Stacks on the sdk bridge PR** (urnetwork/sdk, "bridge the reliability surface over DeviceLocalRpc"). Merge that first — this does not compile without it. On iOS the sdk device lives in the packet-tunnel extension and the app holds a `DeviceRemote`; none of the reliability surface crossed that boundary.

## What ships

**Developer screen** (`Main/Account/Settings/Developer/`, reached from a Settings row on both platforms) — the Android screen ported by content: measurements panel (blast radius, recovery, never-came-back, held verdicts, probes, removals), the five control sections (Detection / Placement / Recovery / Probing / Observability) writing runtime overrides that take effect on the next packet, per-exit rows with tier / flows / warning cause / benched state, and Migrate + global actions. All 34 settings and 26 metrics fields are mirrored 1:1 with the sdk.

**Live destination→exit attribution** — each row in the split-rules / stats view shows "via &lt;exit&gt;" chips for the exits *currently* carrying that cluster's flows. Two chips on one row is a site split across egress IPs, which is the exact event the affinity work exists to prevent, so it is styled distinctly.

**Three-state site rules** — EXCLUDED / PINNED / INCLUDED, writing the same `RouteOverride` values the Android dialog writes.

## Deliberately not ported

**Per-app pinning and per-app split tunneling.** Android attributes a flow to an app via `getConnectionOwnerUid`; iOS has no equivalent, and per-app VPN is MDM/supervised-device machinery. `FlowOwnerLookup` is left un-bridged and the `app:` affinity path stays dormant here.

That distinction matters for what site pinning means on this platform, and the UI copy says so plainly: `RouteOverride.Pin` consolidates flows into one app-scoped affinity group **only for an app rule** — that is what makes an app's API and its CDNs share one egress IP. For a **site** rule the flows keep their ordinary per-domain grouping and gain only a longer tolerance for a quarantined exit. So pinning a site on iOS buys *fewer mid-session exit changes*, not one shared egress IP; multi-subdomain consolidation comes from the CDN-constellation alias table, which works everywhere.

## Implementation notes for review

- Both new polling stores (reliability, exit attribution) gate on view visibility **and** `presentationActive`, so nothing polls into the extension when backgrounded or with a hidden/occluded macOS window. The attribution refresh is rate-floored: block actions flush on connect's 1s event epoch, and each destination-exit call walks the live-flow table under the datapath lock on the far side.
- Settings edits are a read-modify-write of the **whole** struct from a fresh read, serialized on one queue. Both halves are load-bearing: the fresh read means a field this app does not model cannot be zeroed, and the serialization means two knobs changed inside one RPC round trip do not lose one — an A/B screen that silently drops a setting is worse than none.
- The screen reads `nil` settings as "nothing in force" and shows a connect hint rather than presenting last session's values as effective, since the extension is stopped on every disconnect.
- Warning causes render verbatim, so causes added on the Go side later appear without an app update.
- The Developer row is unconditional, matching Android's. Flagging it explicitly since it is the one user-visible surface change on this PR.

Verified by CI for **both** iOS and macOS destinations (unsigned IPA + macOS app produced). Every work package was reviewed by a separate agent before merge, then the whole diff by an integration reviewer; findings from those passes are fixed in the branch, including a build break, the settings zero-value trap, an attribution refresh that could wedge permanently, and the RPC rate issue above. Runtime behavior is verified by live testing on device, not by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
